### PR TITLE
feat: crear interfaz para pedidos y administración

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Panel de administración - Frigorífico Kosher</title>
+  <link rel="stylesheet" href="assets/css/styles.css">
+</head>
+<body>
+  <header class="subheader">
+    <a class="subheader__back" href="index.html">&larr; Inicio</a>
+    <h1>Panel de administración</h1>
+  </header>
+
+  <main class="container" id="adminApp">
+    <section class="card" id="loginSection">
+      <h2>Identificación</h2>
+      <p>Ingrese su nombre para acceder al panel.</p>
+      <form id="loginForm" class="form">
+        <label for="adminName">Nombre del administrador</label>
+        <input id="adminName" name="adminName" type="text" required placeholder="Ej: Juan Pérez">
+        <button class="button" type="submit">Ingresar</button>
+      </form>
+    </section>
+
+    <section class="card card--hidden" id="panelSection">
+      <div class="panel__header">
+        <h2>Bienvenido, <span id="adminNameDisplay"></span></h2>
+        <button class="button button--secondary" id="logoutButton">Cerrar sesión</button>
+      </div>
+
+      <div class="grid">
+        <section class="card" id="inventorySection">
+          <h3>Stock y precios</h3>
+          <p>Actualice el stock disponible y el precio por cajón.</p>
+          <div class="table" role="table">
+            <div class="table__header" role="row">
+              <span role="columnheader">Cajón</span>
+              <span role="columnheader">Stock disponible</span>
+              <span role="columnheader">Precio (ARS)</span>
+            </div>
+            <div id="inventoryRows"></div>
+          </div>
+          <button class="button" id="saveInventory">Guardar cambios</button>
+        </section>
+
+        <section class="card" id="ordersSection">
+          <h3>Historial de pedidos</h3>
+          <p>Últimos pedidos enviados por los clientes.</p>
+          <ul class="history" id="ordersHistory"></ul>
+        </section>
+
+        <section class="card" id="adminHistorySection">
+          <h3>Ingresos de administradores</h3>
+          <p>Registro de accesos recientes al panel.</p>
+          <ul class="history" id="adminHistory"></ul>
+        </section>
+      </div>
+    </section>
+  </main>
+
+  <footer class="footer">
+    <p>&copy; <span id="year"></span> Frigorífico Kosher. Solo para uso interno.</p>
+  </footer>
+
+  <script src="assets/js/admin.js"></script>
+</body>
+</html>

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1,0 +1,285 @@
+:root {
+  --primary: #1f6f8b;
+  --secondary: #99a8b2;
+  --accent: #f2a154;
+  --background: #f7f9fb;
+  --text: #1b1b1f;
+  --muted: #6c757d;
+  --radius: 12px;
+  --shadow: 0 12px 32px rgba(31, 111, 139, 0.15);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: "Inter", "Segoe UI", sans-serif;
+  background: var(--background);
+  color: var(--text);
+  line-height: 1.6;
+}
+
+a {
+  color: inherit;
+}
+
+.hero {
+  background: linear-gradient(135deg, rgba(31, 111, 139, 0.95), rgba(242, 161, 84, 0.85)),
+    url('https://images.unsplash.com/photo-1615486170826-793623581b1f?auto=format&fit=crop&w=1600&q=80') center/cover;
+  color: #fff;
+  padding: 6rem 1.5rem;
+  text-align: center;
+}
+
+.hero__content {
+  max-width: 720px;
+  margin: 0 auto;
+}
+
+.hero__content h1 {
+  font-size: clamp(2.5rem, 5vw, 3.5rem);
+  margin-bottom: 1rem;
+}
+
+.hero__content p {
+  font-size: 1.2rem;
+  margin-bottom: 2rem;
+}
+
+.hero__links {
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.85rem 1.8rem;
+  border-radius: var(--radius);
+  background-color: var(--accent);
+  color: #fff;
+  font-weight: 600;
+  text-decoration: none;
+  border: none;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.button:hover,
+.button:focus {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 20px rgba(242, 161, 84, 0.35);
+}
+
+.button--secondary {
+  background-color: var(--primary);
+}
+
+.container {
+  max-width: 960px;
+  margin: -3rem auto 3rem;
+  padding: 0 1.5rem;
+}
+
+.card {
+  background: #fff;
+  padding: 2rem;
+  margin-bottom: 2rem;
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+}
+
+.card--highlight {
+  border-top: 6px solid var(--accent);
+}
+
+.list {
+  list-style: none;
+  padding: 0;
+  margin: 1rem 0 0;
+}
+
+.list--ordered {
+  counter-reset: steps;
+}
+
+.list--ordered li {
+  counter-increment: steps;
+  margin-bottom: 0.75rem;
+  padding-left: 2.5rem;
+  position: relative;
+}
+
+.list--ordered li::before {
+  content: counter(steps);
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 1.75rem;
+  height: 1.75rem;
+  border-radius: 50%;
+  background: var(--primary);
+  color: #fff;
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.footer {
+  text-align: center;
+  padding: 2rem 1rem 3rem;
+  color: var(--muted);
+}
+
+.footer span {
+  font-weight: 600;
+}
+
+.subheader {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 1.5rem;
+  background: #fff;
+  box-shadow: var(--shadow);
+  position: sticky;
+  top: 0;
+  z-index: 10;
+}
+
+.subheader__back {
+  text-decoration: none;
+  font-weight: 600;
+  color: var(--primary);
+}
+
+.form {
+  display: grid;
+  gap: 1rem;
+}
+
+.form label,
+.form legend {
+  font-weight: 600;
+}
+
+.form input[type="text"],
+.form input[type="number"] {
+  padding: 0.75rem 1rem;
+  border-radius: var(--radius);
+  border: 1px solid #d8dee4;
+  font-size: 1rem;
+}
+
+.form__fieldset {
+  border: 1px solid #d8dee4;
+  border-radius: var(--radius);
+  padding: 1rem;
+}
+
+.radio {
+  display: block;
+  margin-bottom: 0.5rem;
+}
+
+.grid {
+  display: grid;
+  gap: 1.5rem;
+}
+
+@media (min-width: 960px) {
+  .grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  #adminHistorySection {
+    grid-column: span 2;
+  }
+}
+
+.table {
+  border: 1px solid #e3e7ec;
+  border-radius: var(--radius);
+  overflow: hidden;
+}
+
+.table__header,
+.table__row {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  padding: 0.85rem 1rem;
+  align-items: center;
+}
+
+.table__header {
+  background: rgba(31, 111, 139, 0.08);
+  font-weight: 600;
+}
+
+.table__row:nth-child(even) {
+  background: rgba(31, 111, 139, 0.04);
+}
+
+.table__row input {
+  width: 100%;
+}
+
+.history {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.history li {
+  padding: 0.75rem 1rem;
+  border-radius: var(--radius);
+  background: rgba(31, 111, 139, 0.08);
+  line-height: 1.4;
+}
+
+.card--hidden {
+  display: none;
+}
+
+.confirmation__details {
+  margin: 1.5rem 0;
+  padding: 1.5rem;
+  background: rgba(31, 111, 139, 0.08);
+  border-radius: var(--radius);
+}
+
+.panel__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+@media (max-width: 640px) {
+  .hero {
+    padding: 4rem 1.5rem;
+  }
+
+  .container {
+    margin-top: -2rem;
+  }
+
+  .table__header,
+  .table__row {
+    grid-template-columns: 1.2fr 0.8fr 1fr;
+  }
+
+  .panel__header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -1,0 +1,247 @@
+const STORAGE_KEYS = {
+  inventory: 'frigorifico_inventory',
+  orders: 'frigorifico_orders',
+  adminHistory: 'frigorifico_admin_history',
+  currentAdmin: 'frigorifico_current_admin'
+};
+
+const CRATE_OPTIONS = [
+  { id: '6', label: 'Cajón de 6 cabezas' },
+  { id: '7', label: 'Cajón de 7 cabezas' },
+  { id: '8', label: 'Cajón de 8 cabezas' },
+  { id: '9', label: 'Cajón de 9 cabezas' },
+  { id: '10', label: 'Cajón de 10 cabezas' }
+];
+
+document.addEventListener('DOMContentLoaded', () => {
+  const yearSpan = document.getElementById('year');
+  if (yearSpan) {
+    yearSpan.textContent = new Date().getFullYear();
+  }
+
+  const loginSection = document.getElementById('loginSection');
+  const panelSection = document.getElementById('panelSection');
+  const loginForm = document.getElementById('loginForm');
+  const adminNameDisplay = document.getElementById('adminNameDisplay');
+  const logoutButton = document.getElementById('logoutButton');
+  const inventoryRowsContainer = document.getElementById('inventoryRows');
+  const saveInventoryButton = document.getElementById('saveInventory');
+  const ordersHistory = document.getElementById('ordersHistory');
+  const adminHistoryList = document.getElementById('adminHistory');
+
+  let inventoryState = loadInventory();
+
+  renderInventoryRows(inventoryState, inventoryRowsContainer);
+  renderOrdersHistory(ordersHistory);
+  renderAdminHistory(adminHistoryList);
+
+  loginForm.addEventListener('submit', (event) => {
+    event.preventDefault();
+    const formData = new FormData(loginForm);
+    const name = (formData.get('adminName') || '').toString().trim();
+
+    if (!name) {
+      loginForm.adminName.focus();
+      return;
+    }
+
+    adminNameDisplay.textContent = name;
+    loginSection.classList.add('card--hidden');
+    panelSection.classList.remove('card--hidden');
+    loginForm.reset();
+
+    persistAdminLogin(name);
+    renderAdminHistory(adminHistoryList);
+
+    localStorage.setItem(STORAGE_KEYS.currentAdmin, name);
+  });
+
+  logoutButton.addEventListener('click', () => {
+    panelSection.classList.add('card--hidden');
+    loginSection.classList.remove('card--hidden');
+    localStorage.removeItem(STORAGE_KEYS.currentAdmin);
+  });
+
+  saveInventoryButton.addEventListener('click', () => {
+    const updatedInventory = CRATE_OPTIONS.map((crate) => {
+      const stockInput = inventoryRowsContainer.querySelector(
+        `input[data-type="stock"][data-id="${crate.id}"]`
+      );
+      const priceInput = inventoryRowsContainer.querySelector(
+        `input[data-type="price"][data-id="${crate.id}"]`
+      );
+
+      const stock = Number.parseInt(stockInput?.value ?? '0', 10);
+      const price = Number.parseFloat(priceInput?.value ?? '0');
+
+      return {
+        id: crate.id,
+        label: crate.label,
+        stock: Number.isFinite(stock) && stock >= 0 ? stock : 0,
+        price: Number.isFinite(price) && price >= 0 ? Number(price.toFixed(2)) : 0
+      };
+    });
+
+    inventoryState = updatedInventory;
+    localStorage.setItem(STORAGE_KEYS.inventory, JSON.stringify(updatedInventory));
+
+    saveInventoryButton.textContent = 'Cambios guardados';
+    saveInventoryButton.disabled = true;
+    setTimeout(() => {
+      saveInventoryButton.textContent = 'Guardar cambios';
+      saveInventoryButton.disabled = false;
+    }, 1500);
+  });
+
+  inventoryRowsContainer.addEventListener('input', () => {
+    saveInventoryButton.textContent = 'Guardar cambios';
+    saveInventoryButton.disabled = false;
+  });
+
+  const storedAdmin = localStorage.getItem(STORAGE_KEYS.currentAdmin);
+  if (storedAdmin) {
+    adminNameDisplay.textContent = storedAdmin;
+    loginSection.classList.add('card--hidden');
+    panelSection.classList.remove('card--hidden');
+  }
+});
+
+function loadInventory() {
+  const stored = localStorage.getItem(STORAGE_KEYS.inventory);
+  if (stored) {
+    try {
+      const parsed = JSON.parse(stored);
+      if (Array.isArray(parsed) && parsed.length) {
+        return CRATE_OPTIONS.map((option) => {
+          const match = parsed.find((item) => item.id === option.id);
+          return {
+            id: option.id,
+            label: option.label,
+            stock: match?.stock ?? 0,
+            price: match?.price ?? 0
+          };
+        });
+      }
+    } catch (error) {
+      console.error('Error al leer el inventario almacenado', error);
+    }
+  }
+
+  return CRATE_OPTIONS.map((option) => ({
+    id: option.id,
+    label: option.label,
+    stock: 0,
+    price: 0
+  }));
+}
+
+function renderInventoryRows(inventory, container) {
+  container.innerHTML = inventory
+    .map(
+      (item) => `
+        <div class="table__row" role="row">
+          <span>${item.label}</span>
+          <input type="number" min="0" step="1" data-type="stock" data-id="${item.id}" value="${item.stock}">
+          <input type="number" min="0" step="0.01" data-type="price" data-id="${item.id}" value="${item.price}">
+        </div>
+      `
+    )
+    .join('');
+}
+
+function renderOrdersHistory(container) {
+  const stored = localStorage.getItem(STORAGE_KEYS.orders);
+  let orders = [];
+  if (stored) {
+    try {
+      const parsed = JSON.parse(stored);
+      if (Array.isArray(parsed)) {
+        orders = parsed;
+      }
+    } catch (error) {
+      console.error('Error al leer pedidos guardados', error);
+    }
+  }
+
+  if (!orders.length) {
+    container.innerHTML = '<li>No hay pedidos registrados aún.</li>';
+    return;
+  }
+
+  const formatter = new Intl.DateTimeFormat('es-AR', {
+    dateStyle: 'medium',
+    timeStyle: 'short'
+  });
+
+  container.innerHTML = orders
+    .slice()
+    .reverse()
+    .map((order) => {
+      const timestamp = order.timestamp ? formatter.format(new Date(order.timestamp)) : 'Fecha no disponible';
+      return `
+        <li>
+          <strong>${order.storeName}</strong> (${timestamp})<br>
+          ${order.storeAddress}<br>
+          Pedido: ${order.crateSize}
+        </li>
+      `;
+    })
+    .join('');
+}
+
+function persistAdminLogin(name) {
+  const stored = localStorage.getItem(STORAGE_KEYS.adminHistory);
+  let history = [];
+
+  if (stored) {
+    try {
+      const parsed = JSON.parse(stored);
+      if (Array.isArray(parsed)) {
+        history = parsed;
+      }
+    } catch (error) {
+      console.error('Error al leer historial de administradores', error);
+    }
+  }
+
+  history.push({ name, timestamp: Date.now() });
+  const trimmedHistory = history.slice(-20);
+  localStorage.setItem(STORAGE_KEYS.adminHistory, JSON.stringify(trimmedHistory));
+}
+
+function renderAdminHistory(container) {
+  const stored = localStorage.getItem(STORAGE_KEYS.adminHistory);
+  let history = [];
+
+  if (stored) {
+    try {
+      const parsed = JSON.parse(stored);
+      if (Array.isArray(parsed)) {
+        history = parsed;
+      }
+    } catch (error) {
+      console.error('Error al leer historial de administradores', error);
+    }
+  }
+
+  if (!history.length) {
+    container.innerHTML = '<li>Aún no hay ingresos registrados.</li>';
+    return;
+  }
+
+  const formatter = new Intl.DateTimeFormat('es-AR', {
+    dateStyle: 'medium',
+    timeStyle: 'short'
+  });
+
+  container.innerHTML = history
+    .slice()
+    .reverse()
+    .map((entry) => `
+      <li>
+        <strong>${entry.name}</strong><br>
+        ${formatter.format(new Date(entry.timestamp))}
+      </li>
+    `)
+    .join('');
+}

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -1,0 +1,6 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const yearSpan = document.getElementById('year');
+  if (yearSpan) {
+    yearSpan.textContent = new Date().getFullYear();
+  }
+});

--- a/assets/js/pedido.js
+++ b/assets/js/pedido.js
@@ -1,0 +1,99 @@
+const ORDER_STORAGE_KEY = 'frigorifico_orders';
+const INVENTORY_STORAGE_KEY = 'frigorifico_inventory';
+
+document.addEventListener('DOMContentLoaded', () => {
+  const yearSpan = document.getElementById('year');
+  if (yearSpan) {
+    yearSpan.textContent = new Date().getFullYear();
+  }
+
+  const orderSection = document.getElementById('orderSection');
+  const orderForm = document.getElementById('orderForm');
+  const confirmationSection = document.getElementById('confirmation');
+  const confirmationDetails = document.getElementById('confirmationDetails');
+  const newOrderButton = document.getElementById('newOrder');
+
+  orderForm.addEventListener('submit', (event) => {
+    event.preventDefault();
+    const formData = new FormData(orderForm);
+
+    const storeName = (formData.get('storeName') || '').toString().trim();
+    const storeAddress = (formData.get('storeAddress') || '').toString().trim();
+    const crateSize = formData.get('crateSize');
+
+    if (!storeName || !storeAddress || !crateSize) {
+      return;
+    }
+
+    const order = {
+      storeName,
+      storeAddress,
+      crateSize,
+      timestamp: Date.now()
+    };
+
+    persistOrder(order);
+
+    const inventory = loadInventory();
+    const crateData = inventory.find((item) => item.label.includes(crateSize));
+    const details = [
+      `<strong>Comercio:</strong> ${storeName}`,
+      `<strong>Dirección:</strong> ${storeAddress}`,
+      `<strong>Cajón solicitado:</strong> ${crateSize}`
+    ];
+
+    if (crateData) {
+      details.push(`<strong>Precio vigente:</strong> ARS ${Number(crateData.price || 0).toLocaleString('es-AR', { minimumFractionDigits: 2 })}`);
+      details.push(`<strong>Stock disponible:</strong> ${crateData.stock} cajones`);
+    }
+
+    confirmationDetails.innerHTML = details
+      .map((detail) => `<p>${detail}</p>`)
+      .join('');
+
+    orderSection.classList.add('card--hidden');
+    confirmationSection.classList.remove('card--hidden');
+    orderForm.reset();
+  });
+
+  newOrderButton.addEventListener('click', () => {
+    confirmationSection.classList.add('card--hidden');
+    orderSection.classList.remove('card--hidden');
+    confirmationDetails.innerHTML = '';
+  });
+});
+
+function persistOrder(order) {
+  const stored = localStorage.getItem(ORDER_STORAGE_KEY);
+  let orders = [];
+
+  if (stored) {
+    try {
+      const parsed = JSON.parse(stored);
+      if (Array.isArray(parsed)) {
+        orders = parsed;
+      }
+    } catch (error) {
+      console.error('Error al leer pedidos guardados', error);
+    }
+  }
+
+  orders.push(order);
+  localStorage.setItem(ORDER_STORAGE_KEY, JSON.stringify(orders));
+}
+
+function loadInventory() {
+  const stored = localStorage.getItem(INVENTORY_STORAGE_KEY);
+  if (stored) {
+    try {
+      const parsed = JSON.parse(stored);
+      if (Array.isArray(parsed)) {
+        return parsed;
+      }
+    } catch (error) {
+      console.error('Error al leer el inventario', error);
+    }
+  }
+
+  return [];
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Frigorífico Kosher - Pedidos Mayoristas</title>
+  <link rel="stylesheet" href="assets/css/styles.css">
+</head>
+<body>
+  <header class="hero">
+    <div class="hero__content">
+      <h1>Frigorífico Kosher</h1>
+      <p>Distribución mayorista de pollos kosher en cajones seleccionados.</p>
+      <div class="hero__links">
+        <a class="button" href="admin.html">Acceso administradores</a>
+        <a class="button button--secondary" href="pedido.html">Realizar pedido</a>
+      </div>
+    </div>
+  </header>
+
+  <main class="container">
+    <section class="card">
+      <h2>Nuestros productos</h2>
+      <p>
+        Trabajamos exclusivamente con cajones de pollos kosher cuidadosamente seleccionados.
+        No realizamos pedidos particulares, únicamente ventas por cajones.
+      </p>
+      <ul class="list">
+        <li>Cajones mixtos de 6 cabezas</li>
+        <li>Cajones mixtos de 7 cabezas</li>
+        <li>Cajones mixtos de 8 cabezas</li>
+        <li>Cajones mixtos de 9 cabezas</li>
+        <li>Cajones mixtos de 10 cabezas</li>
+      </ul>
+    </section>
+
+    <section class="card card--highlight">
+      <h2>¿Cómo trabajamos?</h2>
+      <ol class="list list--ordered">
+        <li>El administrador actualiza precios y stock disponibles.</li>
+        <li>Los clientes mayoristas envían su pedido indicando su comercio y dirección.</li>
+        <li>Confirmamos la disponibilidad y coordinamos la entrega.</li>
+      </ol>
+      <p>
+        Haga clic en el enlace correspondiente para continuar según su perfil.
+      </p>
+    </section>
+  </main>
+
+  <footer class="footer">
+    <p>&copy; <span id="year"></span> Frigorífico Kosher. Todos los derechos reservados.</p>
+  </footer>
+
+  <script src="assets/js/index.js"></script>
+</body>
+</html>

--- a/pedido.html
+++ b/pedido.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Enviar pedido - Frigorífico Kosher</title>
+  <link rel="stylesheet" href="assets/css/styles.css">
+</head>
+<body>
+  <header class="subheader">
+    <a class="subheader__back" href="index.html">&larr; Inicio</a>
+    <h1>Solicitud de pedido mayorista</h1>
+  </header>
+
+  <main class="container">
+    <section class="card" id="orderSection">
+      <h2>Complete los datos de su comercio</h2>
+      <form id="orderForm" class="form">
+        <label for="storeName">Nombre del local</label>
+        <input id="storeName" name="storeName" type="text" required placeholder="Ej: Carnicería Kosher Central">
+
+        <label for="storeAddress">Dirección completa</label>
+        <input id="storeAddress" name="storeAddress" type="text" required placeholder="Ej: Av. Ejemplo 1234, CABA">
+
+        <fieldset class="form__fieldset">
+          <legend>¿Qué cajón necesita?</legend>
+          <label class="radio">
+            <input type="radio" name="crateSize" value="6 cabezas" required>
+            Cajón de 6 cabezas
+          </label>
+          <label class="radio">
+            <input type="radio" name="crateSize" value="7 cabezas">
+            Cajón de 7 cabezas
+          </label>
+          <label class="radio">
+            <input type="radio" name="crateSize" value="8 cabezas">
+            Cajón de 8 cabezas
+          </label>
+          <label class="radio">
+            <input type="radio" name="crateSize" value="9 cabezas">
+            Cajón de 9 cabezas
+          </label>
+          <label class="radio">
+            <input type="radio" name="crateSize" value="10 cabezas">
+            Cajón de 10 cabezas
+          </label>
+        </fieldset>
+
+        <button class="button" type="submit">Enviar pedido</button>
+      </form>
+    </section>
+
+    <section class="card card--hidden" id="confirmation">
+      <h2>¡Gracias por su pedido!</h2>
+      <p>Hemos registrado su solicitud. Un representante se comunicará para confirmar la disponibilidad.</p>
+      <div class="confirmation__details" id="confirmationDetails"></div>
+      <button class="button button--secondary" id="newOrder">Cargar otro pedido</button>
+    </section>
+  </main>
+
+  <footer class="footer">
+    <p>&copy; <span id="year"></span> Frigorífico Kosher. Ventas mayoristas.</p>
+  </footer>
+
+  <script src="assets/js/pedido.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- crear página principal con accesos diferenciados para administradores y clientes
- implementar panel de administración con control de stock, precios e historial de ingresos
- habilitar formulario de pedidos mayoristas que registra solicitudes y muestra confirmación

## Testing
- no automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cd52be67308332968be52a37f28ab2