### PR TITLE
feat: agregar cantidad y cajon x en pedidos

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Panel de administración - Frigorífico Kosher</title>
+  <link rel="stylesheet" href="assets/css/styles.css">
+</head>
+<body>
+  <header class="subheader">
+    <a class="subheader__back" href="index.html">&larr; Inicio</a>
+    <h1>Panel de administración</h1>
+  </header>
+
+  <main class="container" id="adminApp">
+    <section class="card" id="loginSection">
+      <h2>Identificación</h2>
+      <p>Ingrese su nombre para acceder al panel.</p>
+      <form id="loginForm" class="form">
+        <label for="adminName">Nombre del administrador</label>
+        <input id="adminName" name="adminName" type="text" required placeholder="Ej: Juan Pérez">
+        <button class="button" type="submit">Ingresar</button>
+      </form>
+    </section>
+
+    <section class="card card--hidden" id="panelSection">
+      <div class="panel__header">
+        <h2>Bienvenido, <span id="adminNameDisplay"></span></h2>
+        <button class="button button--secondary" id="logoutButton">Cerrar sesión</button>
+      </div>
+
+      <div class="grid">
+        <section class="card" id="inventorySection">
+          <h3>Stock y precios</h3>
+          <p>Actualice el stock disponible y el precio por cajón.</p>
+          <div class="table" role="table">
+            <div class="table__header" role="row">
+              <span role="columnheader">Cajón</span>
+              <span role="columnheader">Stock disponible</span>
+              <span role="columnheader">Precio (ARS)</span>
+            </div>
+            <div id="inventoryRows"></div>
+          </div>
+          <button class="button" id="saveInventory">Guardar cambios</button>
+        </section>
+
+        <section class="card" id="ordersSection">
+          <h3>Historial de pedidos</h3>
+          <p>Últimos pedidos enviados por los clientes.</p>
+          <ul class="history" id="ordersHistory"></ul>
+        </section>
+
+        <section class="card" id="adminHistorySection">
+          <h3>Ingresos de administradores</h3>
+          <p>Registro de accesos recientes al panel.</p>
+          <ul class="history" id="adminHistory"></ul>
+        </section>
+      </div>
+    </section>
+  </main>
+
+  <footer class="footer">
+    <p>&copy; <span id="year"></span> Frigorífico Kosher. Solo para uso interno.</p>
+  </footer>
+
+  <script src="assets/js/admin.js"></script>
+</body>
+</html>

--- a/admin.html
+++ b/admin.html
@@ -48,7 +48,16 @@
         </section>
 
         <section class="card" id="ordersSection">
-          <h3>Historial de pedidos</h3>
+          <div class="panel__sectionHeader">
+            <h3>Historial de pedidos</h3>
+            <button
+              class="button button--danger"
+              type="button"
+              id="clearOrdersButton"
+              hidden
+              disabled
+            >Borrar historial</button>
+          </div>
           <p>Últimos pedidos enviados por los clientes.</p>
           <ul class="history" id="ordersHistory"></ul>
         </section>

--- a/admin.html
+++ b/admin.html
@@ -67,6 +67,12 @@
           <p>Registro de accesos recientes al panel.</p>
           <ul class="history" id="adminHistory"></ul>
         </section>
+
+        <section class="card" id="adminLogsSection">
+          <h3>Registro de acciones</h3>
+          <p>Últimas operaciones realizadas por los administradores.</p>
+          <ul class="history" id="adminLogs"></ul>
+        </section>
       </div>
     </section>
   </main>

--- a/admin.html
+++ b/admin.html
@@ -6,9 +6,9 @@
   <title>Panel de administración - Frigorífico Kosher</title>
   <link rel="stylesheet" href="assets/css/styles.css">
 </head>
-<body>
+<body class="page page--transition">
   <header class="subheader">
-    <a class="subheader__back" href="index.html">&larr; Inicio</a>
+    <a class="subheader__back" href="index.html" data-transition>&larr; Inicio</a>
     <h1>Panel de administración</h1>
   </header>
 
@@ -24,6 +24,14 @@
         <p class="form__message form__message--error" id="loginError" hidden aria-live="polite"></p>
         <button class="button" type="submit">Ingresar</button>
       </form>
+    </section>
+
+    <section class="card card--hidden" id="adminProcessingSection" aria-live="polite">
+      <h2>Validando acceso</h2>
+      <p>Preparando la información más reciente del panel...</p>
+      <div class="progress">
+        <div class="progress__bar" id="adminProcessingBar"></div>
+      </div>
     </section>
 
     <section class="card card--hidden" id="panelSection">

--- a/admin.html
+++ b/admin.html
@@ -8,7 +8,10 @@
 </head>
 <body class="page page--transition">
   <header class="subheader">
-    <a class="subheader__back" href="index.html" data-transition>&larr; Inicio</a>
+    <a class="subheader__back" href="index.html" data-transition>
+      <span class="subheader__icon" aria-hidden="true">🏠</span>
+      <span class="subheader__label">Salir</span>
+    </a>
     <h1>Panel de administración</h1>
   </header>
 

--- a/admin.html
+++ b/admin.html
@@ -15,10 +15,13 @@
   <main class="container" id="adminApp">
     <section class="card" id="loginSection">
       <h2>Identificación</h2>
-      <p>Ingrese su nombre para acceder al panel.</p>
+      <p>Ingrese sus credenciales para acceder al panel.</p>
       <form id="loginForm" class="form">
         <label for="adminName">Nombre del administrador</label>
         <input id="adminName" name="adminName" type="text" required placeholder="Ej: Juan Pérez">
+        <label for="adminPassword">Contraseña</label>
+        <input id="adminPassword" name="adminPassword" type="password" required placeholder="Ingrese su contraseña">
+        <p class="form__message form__message--error" id="loginError" hidden aria-live="polite"></p>
         <button class="button" type="submit">Ingresar</button>
       </form>
     </section>

--- a/admin.html
+++ b/admin.html
@@ -73,6 +73,24 @@
           <p>Últimas operaciones realizadas por los administradores.</p>
           <ul class="history" id="adminLogs"></ul>
         </section>
+
+        <section class="card card--hidden" id="paymentsSection">
+          <div class="panel__sectionHeader">
+            <h3>Pagos</h3>
+            <button class="button button--secondary" type="button" id="paymentsToggle">Ver pedidos de la semana</button>
+          </div>
+          <p>Gestione los cobros de la semana laboral (lunes a viernes) y registre su estado.</p>
+          <div id="paymentsContent" hidden>
+            <p class="history__groupTitle" id="paymentsRangeLabel"></p>
+            <ul class="history history--payments" id="paymentsList"></ul>
+          </div>
+        </section>
+
+        <section class="card card--hidden" id="paymentLogsSection">
+          <h3>Registro de pagos</h3>
+          <p>Seguimiento exclusivo de los cobros marcados.</p>
+          <ul class="history" id="paymentLogs"></ul>
+        </section>
       </div>
     </section>
   </main>

--- a/admin.html
+++ b/admin.html
@@ -111,6 +111,7 @@
           </div>
           <p>Gestione los cobros de la semana laboral (lunes a viernes) y registre su estado.</p>
           <div id="paymentsContent" hidden>
+            <div class="paymentWeeks" id="paymentWeekSelector"></div>
             <p class="history__groupTitle" id="paymentsRangeLabel"></p>
             <ul class="history history--payments" id="paymentsList"></ul>
           </div>

--- a/admin.html
+++ b/admin.html
@@ -30,6 +30,7 @@
       <h2>Validando acceso</h2>
       <p>Preparando la información más reciente del panel...</p>
       <div class="progress">
+        <span class="progress__label" id="adminProcessingPercent">0%</span>
         <div class="progress__bar" id="adminProcessingBar"></div>
       </div>
     </section>

--- a/admin.html
+++ b/admin.html
@@ -72,13 +72,31 @@
         </section>
 
         <section class="card" id="adminHistorySection">
-          <h3>Ingresos de administradores</h3>
+          <div class="panel__sectionHeader">
+            <h3>Ingresos de administradores</h3>
+            <button
+              class="button button--danger"
+              type="button"
+              id="clearAdminHistoryButton"
+              hidden
+              disabled
+            >Reiniciar</button>
+          </div>
           <p>Registro de accesos recientes al panel.</p>
           <ul class="history" id="adminHistory"></ul>
         </section>
 
         <section class="card" id="adminLogsSection">
-          <h3>Registro de acciones</h3>
+          <div class="panel__sectionHeader">
+            <h3>Registro de acciones</h3>
+            <button
+              class="button button--danger"
+              type="button"
+              id="clearAdminLogsButton"
+              hidden
+              disabled
+            >Reiniciar</button>
+          </div>
           <p>Últimas operaciones realizadas por los administradores.</p>
           <ul class="history" id="adminLogs"></ul>
         </section>
@@ -96,9 +114,32 @@
         </section>
 
         <section class="card card--hidden" id="paymentLogsSection">
-          <h3>Registro de pagos</h3>
+          <div class="panel__sectionHeader">
+            <h3>Registro de pagos</h3>
+            <button
+              class="button button--danger"
+              type="button"
+              id="clearPaymentLogsButton"
+              hidden
+              disabled
+            >Reiniciar</button>
+          </div>
           <p>Seguimiento exclusivo de los cobros marcados.</p>
           <ul class="history" id="paymentLogs"></ul>
+        </section>
+
+        <section class="card card--hidden" id="adminManagementSection">
+          <h3>Gestión de administradores</h3>
+          <p>Agregue nuevos administradores autorizados para el panel.</p>
+          <form id="addAdminForm" class="form">
+            <label for="newAdminName">Nombre del nuevo administrador</label>
+            <input id="newAdminName" name="newAdminName" type="text" placeholder="Ej: Ana" autocomplete="off">
+            <label for="newAdminPassword">Contraseña</label>
+            <input id="newAdminPassword" name="newAdminPassword" type="password" placeholder="Defina una contraseña segura">
+            <p class="form__message" id="addAdminMessage" hidden aria-live="polite"></p>
+            <button class="button" type="submit">Agregar administrador</button>
+          </form>
+          <ul class="history" id="customAdminsList"></ul>
         </section>
       </div>
     </section>

--- a/admin.html
+++ b/admin.html
@@ -109,7 +109,7 @@
             <h3>Pagos</h3>
             <button class="button button--secondary" type="button" id="paymentsToggle">Ver pedidos de la semana</button>
           </div>
-          <p>Gestione los cobros de la semana laboral (lunes a viernes) y registre su estado.</p>
+          <p>Gestione los cobros de la semana en curso (lunes a domingo) y registre su estado.</p>
           <div id="paymentsContent" hidden>
             <div class="paymentWeeks" id="paymentWeekSelector"></div>
             <p class="history__groupTitle" id="paymentsRangeLabel"></p>

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -500,12 +500,12 @@ a {
 .progress {
   position: relative;
   width: 100%;
-  height: 10px;
+  height: 12px;
   border-radius: 999px;
-  background: rgba(31, 111, 139, 0.12);
+  background: rgba(31, 111, 139, 0.18);
   overflow: hidden;
   margin-top: 1.25rem;
-  box-shadow: inset 0 1px 4px rgba(0, 0, 0, 0.05);
+  box-shadow: inset 0 2px 6px rgba(0, 0, 0, 0.08);
 }
 
 .progress__bar {
@@ -521,11 +521,76 @@ a {
   width: 100%;
 }
 
+.progress__label {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #0b3d63;
+  text-shadow: 0 1px 3px rgba(255, 255, 255, 0.8);
+  pointer-events: none;
+}
+
 .confirmation__details {
   margin: 1.5rem 0;
   padding: 1.5rem;
   background: rgba(31, 111, 139, 0.08);
   border-radius: var(--radius);
+}
+
+.confirmation__message {
+  margin: 0 0 1.25rem;
+  font-weight: 600;
+  font-size: 1.05rem;
+}
+
+.confirmation__list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.confirmation__list li {
+  position: relative;
+  padding-left: 1.25rem;
+}
+
+.confirmation__list li::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 0.55rem;
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 50%;
+  background: var(--accent);
+  box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.7);
+}
+
+.card--thanks {
+  background: linear-gradient(160deg, #d5ecff, #9fd3ff);
+  color: #0b3d63;
+  box-shadow: 0 24px 48px rgba(11, 61, 99, 0.25);
+}
+
+.card--thanks h2 {
+  color: inherit;
+}
+
+.card--thanks .confirmation__details {
+  background: rgba(255, 255, 255, 0.85);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.55);
+  color: inherit;
+}
+
+.card--thanks .confirmation__list li::before {
+  background: #0b84d0;
+  box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.9);
 }
 
 .review__intro {

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -22,6 +22,30 @@ body {
   min-height: 100vh;
 }
 
+.page {
+  min-height: 100vh;
+}
+
+.page--transition {
+  opacity: 0;
+  transition: opacity 0.45s ease;
+}
+
+.page--transition.page--ready {
+  opacity: 1;
+}
+
+.page--transition.page--exit {
+  opacity: 0;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .page--transition {
+    transition: none;
+    opacity: 1;
+  }
+}
+
 a {
   color: inherit;
 }
@@ -112,6 +136,10 @@ a {
   box-shadow: var(--shadow);
   overflow: hidden;
   transition: transform 0.25s ease, box-shadow 0.25s ease;
+}
+
+.card--active {
+  animation: cardFadeIn 0.45s ease forwards;
 }
 
 .card::after {
@@ -469,6 +497,30 @@ a {
   color: #8a3b12;
 }
 
+.progress {
+  position: relative;
+  width: 100%;
+  height: 10px;
+  border-radius: 999px;
+  background: rgba(31, 111, 139, 0.12);
+  overflow: hidden;
+  margin-top: 1.25rem;
+  box-shadow: inset 0 1px 4px rgba(0, 0, 0, 0.05);
+}
+
+.progress__bar {
+  position: absolute;
+  inset: 0;
+  width: 0;
+  background: linear-gradient(90deg, var(--accent), var(--primary));
+  border-radius: inherit;
+  transition: width 4s ease;
+}
+
+.progress__bar--animate {
+  width: 100%;
+}
+
 .confirmation__details {
   margin: 1.5rem 0;
   padding: 1.5rem;
@@ -510,6 +562,18 @@ a {
 
 .panel__sectionHeader h3 {
   margin: 0;
+}
+
+@keyframes cardFadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(18px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
 @media (max-width: 640px) {

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -438,6 +438,44 @@ a {
   background: linear-gradient(180deg, rgba(153, 168, 178, 0.7), rgba(31, 111, 139, 0.4));
 }
 
+.paymentWeeks {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.paymentWeeks__empty {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.paymentWeeks__button {
+  padding: 0.4rem 0.9rem;
+  border-radius: 999px;
+  border: 1px solid rgba(31, 111, 139, 0.35);
+  background: rgba(255, 255, 255, 0.65);
+  color: var(--text-primary);
+  font-weight: 600;
+  font-size: 0.9rem;
+  transition: background 200ms ease, color 200ms ease, box-shadow 200ms ease, transform 200ms ease;
+  cursor: pointer;
+}
+
+.paymentWeeks__button:hover {
+  background: rgba(31, 111, 139, 0.1);
+  transform: translateY(-1px);
+  box-shadow: 0 8px 18px rgba(31, 111, 139, 0.18);
+}
+
+.paymentWeeks__button--active {
+  background: linear-gradient(135deg, rgba(31, 111, 139, 0.95), rgba(116, 198, 157, 0.9));
+  color: #fff;
+  border-color: transparent;
+  box-shadow: 0 10px 24px rgba(31, 111, 139, 0.28);
+}
+
 .history--payments .history__item {
   display: flex;
   flex-direction: column;

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -183,9 +183,58 @@ a {
   padding: 1rem;
 }
 
+.form__message {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--muted);
+}
+
+.form__message--error {
+  color: #b42318;
+  font-weight: 500;
+}
+
 .radio {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+  margin-bottom: 0.75rem;
+  padding: 0.75rem 1rem;
+  border: 1px solid #d8dee4;
+  border-radius: var(--radius);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  cursor: pointer;
+}
+
+.radio input[type="radio"] {
+  margin-top: 0.3rem;
+}
+
+.radio__title {
+  font-weight: 600;
+  display: inline-block;
+}
+
+.radio__meta {
   display: block;
-  margin-bottom: 0.5rem;
+  color: var(--muted);
+  font-size: 0.9rem;
+  margin-top: 0.25rem;
+}
+
+.radio:hover,
+.radio:focus-within {
+  border-color: var(--primary);
+  box-shadow: 0 0 0 3px rgba(31, 111, 139, 0.15);
+}
+
+.radio--disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.radio--disabled input {
+  cursor: not-allowed;
 }
 
 .grid {

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -261,6 +261,11 @@ a {
   font-weight: 500;
 }
 
+.form__message--success {
+  color: #027a48;
+  font-weight: 500;
+}
+
 .radio {
   display: flex;
   align-items: flex-start;

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -298,11 +298,48 @@ a {
   display: none;
 }
 
+.alert {
+  border-radius: var(--radius);
+  padding: 1rem 1.25rem;
+  margin-bottom: 1.5rem;
+  font-weight: 600;
+}
+
+.alert[hidden] {
+  display: none;
+}
+
+.alert:not([hidden]) {
+  display: block;
+}
+
+.alert--warning {
+  background: rgba(242, 161, 84, 0.12);
+  border: 1px solid rgba(242, 161, 84, 0.45);
+  color: #8a3b12;
+}
+
 .confirmation__details {
   margin: 1.5rem 0;
   padding: 1.5rem;
   background: rgba(31, 111, 139, 0.08);
   border-radius: var(--radius);
+}
+
+.review__intro {
+  margin-top: 0;
+  color: var(--muted);
+}
+
+.review__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin-top: 1.5rem;
+}
+
+.review__actions .button {
+  flex: 1 1 200px;
 }
 
 .panel__header {

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -337,6 +337,45 @@ a {
   line-height: 1.4;
 }
 
+.history--payments .history__item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.payment__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.payment__details {
+  margin: 0;
+}
+
+.payment__control {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem;
+  margin-top: 0.25rem;
+}
+
+.payment__statusSelect {
+  padding: 0.35rem 0.75rem;
+  border-radius: var(--radius);
+  border: 1px solid #d8dee4;
+  font-size: 0.95rem;
+  min-width: 150px;
+}
+
+.payment__meta {
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
 .card--hidden {
   display: none;
 }

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1,0 +1,285 @@
+:root {
+  --primary: #1f6f8b;
+  --secondary: #99a8b2;
+  --accent: #f2a154;
+  --background: #f7f9fb;
+  --text: #1b1b1f;
+  --muted: #6c757d;
+  --radius: 12px;
+  --shadow: 0 12px 32px rgba(31, 111, 139, 0.15);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: "Inter", "Segoe UI", sans-serif;
+  background: var(--background);
+  color: var(--text);
+  line-height: 1.6;
+}
+
+a {
+  color: inherit;
+}
+
+.hero {
+  background: linear-gradient(135deg, rgba(31, 111, 139, 0.95), rgba(242, 161, 84, 0.85)),
+    url('https://images.unsplash.com/photo-1615486170826-793623581b1f?auto=format&fit=crop&w=1600&q=80') center/cover;
+  color: #fff;
+  padding: 6rem 1.5rem;
+  text-align: center;
+}
+
+.hero__content {
+  max-width: 720px;
+  margin: 0 auto;
+}
+
+.hero__content h1 {
+  font-size: clamp(2.5rem, 5vw, 3.5rem);
+  margin-bottom: 1rem;
+}
+
+.hero__content p {
+  font-size: 1.2rem;
+  margin-bottom: 2rem;
+}
+
+.hero__links {
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.85rem 1.8rem;
+  border-radius: var(--radius);
+  background-color: var(--accent);
+  color: #fff;
+  font-weight: 600;
+  text-decoration: none;
+  border: none;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.button:hover,
+.button:focus {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 20px rgba(242, 161, 84, 0.35);
+}
+
+.button--secondary {
+  background-color: var(--primary);
+}
+
+.container {
+  max-width: 960px;
+  margin: -3rem auto 3rem;
+  padding: 0 1.5rem;
+}
+
+.card {
+  background: #fff;
+  padding: 2rem;
+  margin-bottom: 2rem;
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+}
+
+.card--highlight {
+  border-top: 6px solid var(--accent);
+}
+
+.list {
+  list-style: none;
+  padding: 0;
+  margin: 1rem 0 0;
+}
+
+.list--ordered {
+  counter-reset: steps;
+}
+
+.list--ordered li {
+  counter-increment: steps;
+  margin-bottom: 0.75rem;
+  padding-left: 2.5rem;
+  position: relative;
+}
+
+.list--ordered li::before {
+  content: counter(steps);
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 1.75rem;
+  height: 1.75rem;
+  border-radius: 50%;
+  background: var(--primary);
+  color: #fff;
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.footer {
+  text-align: center;
+  padding: 2rem 1rem 3rem;
+  color: var(--muted);
+}
+
+.footer span {
+  font-weight: 600;
+}
+
+.subheader {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 1.5rem;
+  background: #fff;
+  box-shadow: var(--shadow);
+  position: sticky;
+  top: 0;
+  z-index: 10;
+}
+
+.subheader__back {
+  text-decoration: none;
+  font-weight: 600;
+  color: var(--primary);
+}
+
+.form {
+  display: grid;
+  gap: 1rem;
+}
+
+.form label,
+.form legend {
+  font-weight: 600;
+}
+
+.form input[type="text"],
+.form input[type="number"] {
+  padding: 0.75rem 1rem;
+  border-radius: var(--radius);
+  border: 1px solid #d8dee4;
+  font-size: 1rem;
+}
+
+.form__fieldset {
+  border: 1px solid #d8dee4;
+  border-radius: var(--radius);
+  padding: 1rem;
+}
+
+.radio {
+  display: block;
+  margin-bottom: 0.5rem;
+}
+
+.grid {
+  display: grid;
+  gap: 1.5rem;
+}
+
+@media (min-width: 960px) {
+  .grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  #adminHistorySection {
+    grid-column: span 2;
+  }
+}
+
+.table {
+  border: 1px solid #e3e7ec;
+  border-radius: var(--radius);
+  overflow: hidden;
+}
+
+.table__header,
+.table__row {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  padding: 0.85rem 1rem;
+  align-items: center;
+}
+
+.table__header {
+  background: rgba(31, 111, 139, 0.08);
+  font-weight: 600;
+}
+
+.table__row:nth-child(even) {
+  background: rgba(31, 111, 139, 0.04);
+}
+
+.table__row input {
+  width: 100%;
+}
+
+.history {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.history li {
+  padding: 0.75rem 1rem;
+  border-radius: var(--radius);
+  background: rgba(31, 111, 139, 0.08);
+  line-height: 1.4;
+}
+
+.card--hidden {
+  display: none;
+}
+
+.confirmation__details {
+  margin: 1.5rem 0;
+  padding: 1.5rem;
+  background: rgba(31, 111, 139, 0.08);
+  border-radius: var(--radius);
+}
+
+.panel__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+@media (max-width: 640px) {
+  .hero {
+    padding: 4rem 1.5rem;
+  }
+
+  .container {
+    margin-top: -2rem;
+  }
+
+  .table__header,
+  .table__row {
+    grid-template-columns: 1.2fr 0.8fr 1fr;
+  }
+
+  .panel__header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -80,6 +80,22 @@ a {
   background-color: var(--primary);
 }
 
+.button--danger {
+  background-color: #c0392b;
+}
+
+.button:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+  transform: none;
+  box-shadow: none;
+}
+
+.button--danger:hover,
+.button--danger:focus {
+  box-shadow: 0 12px 20px rgba(192, 57, 43, 0.35);
+}
+
 .container {
   max-width: 960px;
   margin: -3rem auto 3rem;
@@ -284,10 +300,37 @@ a {
   padding: 0;
   margin: 0;
   display: grid;
+  gap: 1rem;
+}
+
+.history > li {
+  padding: 1rem;
+  border-radius: var(--radius);
+  background: rgba(31, 111, 139, 0.08);
+}
+
+.history__groupTitle {
+  margin: 0 0 0.75rem;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.history__groupList {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
   gap: 0.75rem;
 }
 
-.history li {
+.history__item {
+  padding: 0.75rem 1rem;
+  border-radius: var(--radius);
+  background: rgba(31, 111, 139, 0.12);
+  line-height: 1.4;
+}
+
+.history__empty {
   padding: 0.75rem 1rem;
   border-radius: var(--radius);
   background: rgba(31, 111, 139, 0.08);
@@ -350,6 +393,18 @@ a {
   margin-bottom: 1.5rem;
 }
 
+.panel__sectionHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 0.75rem;
+}
+
+.panel__sectionHeader h3 {
+  margin: 0;
+}
+
 @media (max-width: 640px) {
   .hero {
     padding: 4rem 1.5rem;
@@ -367,5 +422,14 @@ a {
   .panel__header {
     flex-direction: column;
     align-items: flex-start;
+  }
+
+  .panel__sectionHeader {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .panel__sectionHeader .button {
+    width: 100%;
   }
 }

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -221,9 +221,17 @@ a {
 }
 
 .subheader__back {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
   text-decoration: none;
   font-weight: 600;
   color: var(--primary);
+}
+
+.subheader__icon {
+  font-size: 1.35rem;
+  line-height: 1;
 }
 
 .form {

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -16,9 +16,10 @@
 body {
   margin: 0;
   font-family: "Inter", "Segoe UI", sans-serif;
-  background: var(--background);
+  background: linear-gradient(180deg, #fdfdfd 0%, #eef5f8 45%, #f7f0eb 100%);
   color: var(--text);
   line-height: 1.6;
+  min-height: 100vh;
 }
 
 a {
@@ -103,11 +104,33 @@ a {
 }
 
 .card {
-  background: #fff;
+  position: relative;
+  background: linear-gradient(145deg, rgba(255, 255, 255, 0.95), rgba(241, 248, 251, 0.95));
   padding: 2rem;
   margin-bottom: 2rem;
   border-radius: var(--radius);
   box-shadow: var(--shadow);
+  overflow: hidden;
+  transition: transform 0.25s ease, box-shadow 0.25s ease;
+}
+
+.card::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at top right, rgba(242, 161, 84, 0.15), transparent 55%);
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.3s ease;
+}
+
+.card:hover {
+  transform: translateY(-6px);
+  box-shadow: 0 18px 40px rgba(31, 111, 139, 0.2);
+}
+
+.card:hover::after {
+  opacity: 1;
 }
 
 .card--highlight {
@@ -304,9 +327,19 @@ a {
 }
 
 .history > li {
-  padding: 1rem;
+  position: relative;
+  padding: 1rem 1.25rem 1rem 1.75rem;
   border-radius: var(--radius);
   background: rgba(31, 111, 139, 0.08);
+  overflow: hidden;
+}
+
+.history > li::before {
+  content: "";
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 0.45rem;
+  background: linear-gradient(180deg, var(--primary), rgba(242, 161, 84, 0.85));
 }
 
 .history__groupTitle {
@@ -324,23 +357,58 @@ a {
 }
 
 .history__item {
-  padding: 0.75rem 1rem;
+  position: relative;
+  padding: 0.75rem 1rem 0.75rem 1.6rem;
   border-radius: var(--radius);
   background: rgba(31, 111, 139, 0.12);
   line-height: 1.4;
+  overflow: hidden;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.history__item::before {
+  content: "";
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 0.35rem;
+  background: linear-gradient(180deg, rgba(242, 161, 84, 0.9), rgba(31, 111, 139, 0.9));
+  opacity: 0.85;
+}
+
+.history__item:hover {
+  transform: translateX(4px);
+  box-shadow: 0 12px 24px rgba(31, 111, 139, 0.18);
 }
 
 .history__empty {
-  padding: 0.75rem 1rem;
+  position: relative;
+  padding: 0.75rem 1rem 0.75rem 1.6rem;
   border-radius: var(--radius);
   background: rgba(31, 111, 139, 0.08);
   line-height: 1.4;
+  overflow: hidden;
+}
+
+.history__empty::before {
+  content: "";
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 0.35rem;
+  background: linear-gradient(180deg, rgba(153, 168, 178, 0.7), rgba(31, 111, 139, 0.4));
 }
 
 .history--payments .history__item {
   display: flex;
   flex-direction: column;
   gap: 0.35rem;
+}
+
+.history--payments .history__item::before {
+  background: linear-gradient(180deg, rgba(31, 111, 139, 0.95), rgba(116, 198, 157, 0.9));
+}
+
+.history--payments .history__item:hover {
+  box-shadow: 0 12px 26px rgba(31, 111, 139, 0.25);
 }
 
 .payment__header {

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -88,7 +88,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   if (paymentsToggleButtonRef) {
     paymentsToggleButtonRef.addEventListener('click', () => {
-      if (!isAdminLuca(currentAdminRecord)) {
+      if (!isPaymentsAdmin(currentAdminRecord)) {
         return;
       }
 
@@ -552,7 +552,7 @@ function renderOrdersHistory(container) {
 
   container.innerHTML = groupHtml;
 
-  if (paymentsVisible && isAdminLuca(currentAdminRecord)) {
+  if (paymentsVisible && isPaymentsAdmin(currentAdminRecord)) {
     refreshPaymentsView();
   }
 
@@ -560,10 +560,10 @@ function renderOrdersHistory(container) {
 }
 
 function updateAdminPermissions(adminRecord) {
-  const isLucaActive = isAdminLuca(adminRecord);
+  const isPaymentsAdminActive = isPaymentsAdmin(adminRecord);
 
   if (paymentsSectionRef) {
-    if (isLucaActive) {
+    if (isPaymentsAdminActive) {
       paymentsSectionRef.classList.remove('card--hidden');
       if (paymentsToggleButtonRef) {
         paymentsToggleButtonRef.disabled = false;
@@ -592,7 +592,7 @@ function updateAdminPermissions(adminRecord) {
   }
 
   if (paymentLogsSectionRef) {
-    if (isLucaActive) {
+    if (isPaymentsAdminActive) {
       paymentLogsSectionRef.classList.remove('card--hidden');
       renderPaymentLogs(paymentLogsListRef);
     } else {
@@ -604,7 +604,7 @@ function updateAdminPermissions(adminRecord) {
   }
 }
 
-function isAdminLuca(adminRecord) {
+function isPaymentsAdmin(adminRecord) {
   if (!adminRecord) {
     return false;
   }
@@ -616,7 +616,7 @@ function isAdminLuca(adminRecord) {
       ?? ''
   ).toString().toLowerCase();
 
-  return username === 'luca';
+  return username === 'luca' || username === 'martin';
 }
 
 function handlePaymentStatusChange(event) {
@@ -625,7 +625,7 @@ function handlePaymentStatusChange(event) {
     return;
   }
 
-  if (!isAdminLuca(currentAdminRecord)) {
+  if (!isPaymentsAdmin(currentAdminRecord)) {
     return;
   }
 
@@ -653,7 +653,7 @@ function refreshPaymentsView() {
     return;
   }
 
-  if (!isAdminLuca(currentAdminRecord)) {
+  if (!isPaymentsAdmin(currentAdminRecord)) {
     return;
   }
 
@@ -775,11 +775,6 @@ function getWeekBoundaries(date) {
   const end = new Date(start);
   end.setDate(end.getDate() + 4);
   end.setHours(23, 59, 59, 999);
-
-  const yearEnd = new Date(start.getFullYear(), 11, 31, 23, 59, 59, 999);
-  if (end > yearEnd) {
-    end.setTime(yearEnd.getTime());
-  }
 
   return { start, end };
 }

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -1088,7 +1088,7 @@ function getWeekBoundaries(date) {
   start.setDate(start.getDate() - diffToMonday);
 
   const end = new Date(start);
-  end.setDate(end.getDate() + 4);
+  end.setDate(end.getDate() + 6);
   end.setHours(23, 59, 59, 999);
 
   return { start, end };

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -2,7 +2,6 @@ const STORAGE_KEYS = {
   inventory: 'frigorifico_inventory',
   orders: 'frigorifico_orders',
   adminHistory: 'frigorifico_admin_history',
-  currentAdmin: 'frigorifico_current_admin',
   adminLogs: 'frigorifico_admin_logs',
   payments: 'frigorifico_payment_status',
   paymentLogs: 'frigorifico_payment_logs',
@@ -370,14 +369,6 @@ document.addEventListener('DOMContentLoaded', () => {
     appendAdminLog('Inició sesión', adminDisplayName);
     updateAdminPermissions(currentAdminRecord);
 
-    localStorage.setItem(
-      STORAGE_KEYS.currentAdmin,
-      JSON.stringify({
-        username: adminRecord.username,
-        name: adminDisplayName
-      })
-    );
-
     loginForm.reset();
     loginSection.classList.add('card--hidden');
     panelSection.classList.add('card--hidden');
@@ -402,10 +393,10 @@ document.addEventListener('DOMContentLoaded', () => {
     }
     hideLoginError(loginError);
     currentAdminRecord = null;
+    adminNameDisplay.textContent = '';
     updateClearOrdersButton(false);
     paymentsVisible = false;
     updateAdminPermissions(null);
-    localStorage.removeItem(STORAGE_KEYS.currentAdmin);
   });
 
   saveInventoryButton.addEventListener('click', () => {
@@ -488,27 +479,8 @@ document.addEventListener('DOMContentLoaded', () => {
     saveInventoryButton.disabled = false;
   });
 
-  const storedAdminRaw = localStorage.getItem(STORAGE_KEYS.currentAdmin);
-  const storedAdmin = parseStoredAdmin(storedAdminRaw);
-  const matchedAdmin = storedAdmin
-    ? getAuthorizedAdmin(storedAdmin.username ?? storedAdmin.name)
-    : null;
-
-  if (matchedAdmin) {
-    const adminDisplayName = storedAdmin?.name ?? matchedAdmin.displayName ?? matchedAdmin.username;
-    currentAdminRecord = matchedAdmin;
-    adminNameDisplay.textContent = adminDisplayName;
-    loginSection.classList.add('card--hidden');
-    panelSection.classList.remove('card--hidden');
-    updateClearOrdersButton(loadOrders().length > 0);
-    updateAdminPermissions(currentAdminRecord);
-    activateCard(panelSection);
-  } else if (storedAdminRaw) {
-    localStorage.removeItem(STORAGE_KEYS.currentAdmin);
-    activateCard(loginSection);
-  } else {
-    activateCard(loginSection);
-  }
+  updateAdminPermissions(null);
+  activateCard(loginSection);
 });
 
 function getAuthorizedAdmin(name) {
@@ -542,35 +514,6 @@ function hasAdminPermission(adminRecord, permissionKey) {
 
 function isHistoryClearAllowed(adminRecord) {
   return hasAdminPermission(adminRecord, 'clearOrders');
-}
-
-function parseStoredAdmin(rawValue) {
-  if (!rawValue) {
-    return null;
-  }
-
-  try {
-    const parsed = JSON.parse(rawValue);
-    if (parsed && typeof parsed === 'object') {
-      const result = {};
-      if (typeof parsed.username === 'string') {
-        result.username = parsed.username;
-      }
-      if (typeof parsed.name === 'string') {
-        result.name = parsed.name;
-      }
-
-      if ('username' in result || 'name' in result) {
-        return result;
-      }
-    }
-  } catch (error) {
-    if (typeof rawValue === 'string') {
-      return { name: rawValue };
-    }
-  }
-
-  return null;
 }
 
 function getActiveAdminDisplayName() {

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -1,0 +1,251 @@
+const STORAGE_KEYS = {
+  inventory: 'frigorifico_inventory',
+  orders: 'frigorifico_orders',
+  adminHistory: 'frigorifico_admin_history',
+  currentAdmin: 'frigorifico_current_admin'
+};
+
+const CRATE_OPTIONS = [
+  { id: 'X', label: 'Cajón X' },
+  { id: '6', label: 'Cajón de 6 cabezas' },
+  { id: '7', label: 'Cajón de 7 cabezas' },
+  { id: '8', label: 'Cajón de 8 cabezas' },
+  { id: '9', label: 'Cajón de 9 cabezas' },
+  { id: '10', label: 'Cajón de 10 cabezas' }
+];
+
+document.addEventListener('DOMContentLoaded', () => {
+  const yearSpan = document.getElementById('year');
+  if (yearSpan) {
+    yearSpan.textContent = new Date().getFullYear();
+  }
+
+  const loginSection = document.getElementById('loginSection');
+  const panelSection = document.getElementById('panelSection');
+  const loginForm = document.getElementById('loginForm');
+  const adminNameDisplay = document.getElementById('adminNameDisplay');
+  const logoutButton = document.getElementById('logoutButton');
+  const inventoryRowsContainer = document.getElementById('inventoryRows');
+  const saveInventoryButton = document.getElementById('saveInventory');
+  const ordersHistory = document.getElementById('ordersHistory');
+  const adminHistoryList = document.getElementById('adminHistory');
+
+  let inventoryState = loadInventory();
+
+  renderInventoryRows(inventoryState, inventoryRowsContainer);
+  renderOrdersHistory(ordersHistory);
+  renderAdminHistory(adminHistoryList);
+
+  loginForm.addEventListener('submit', (event) => {
+    event.preventDefault();
+    const formData = new FormData(loginForm);
+    const name = (formData.get('adminName') || '').toString().trim();
+
+    if (!name) {
+      loginForm.adminName.focus();
+      return;
+    }
+
+    adminNameDisplay.textContent = name;
+    loginSection.classList.add('card--hidden');
+    panelSection.classList.remove('card--hidden');
+    loginForm.reset();
+
+    persistAdminLogin(name);
+    renderAdminHistory(adminHistoryList);
+
+    localStorage.setItem(STORAGE_KEYS.currentAdmin, name);
+  });
+
+  logoutButton.addEventListener('click', () => {
+    panelSection.classList.add('card--hidden');
+    loginSection.classList.remove('card--hidden');
+    localStorage.removeItem(STORAGE_KEYS.currentAdmin);
+  });
+
+  saveInventoryButton.addEventListener('click', () => {
+    const updatedInventory = CRATE_OPTIONS.map((crate) => {
+      const stockInput = inventoryRowsContainer.querySelector(
+        `input[data-type="stock"][data-id="${crate.id}"]`
+      );
+      const priceInput = inventoryRowsContainer.querySelector(
+        `input[data-type="price"][data-id="${crate.id}"]`
+      );
+
+      const stock = Number.parseInt(stockInput?.value ?? '0', 10);
+      const price = Number.parseFloat(priceInput?.value ?? '0');
+
+      return {
+        id: crate.id,
+        label: crate.label,
+        stock: Number.isFinite(stock) && stock >= 0 ? stock : 0,
+        price: Number.isFinite(price) && price >= 0 ? Number(price.toFixed(2)) : 0
+      };
+    });
+
+    inventoryState = updatedInventory;
+    localStorage.setItem(STORAGE_KEYS.inventory, JSON.stringify(updatedInventory));
+
+    saveInventoryButton.textContent = 'Cambios guardados';
+    saveInventoryButton.disabled = true;
+    setTimeout(() => {
+      saveInventoryButton.textContent = 'Guardar cambios';
+      saveInventoryButton.disabled = false;
+    }, 1500);
+  });
+
+  inventoryRowsContainer.addEventListener('input', () => {
+    saveInventoryButton.textContent = 'Guardar cambios';
+    saveInventoryButton.disabled = false;
+  });
+
+  const storedAdmin = localStorage.getItem(STORAGE_KEYS.currentAdmin);
+  if (storedAdmin) {
+    adminNameDisplay.textContent = storedAdmin;
+    loginSection.classList.add('card--hidden');
+    panelSection.classList.remove('card--hidden');
+  }
+});
+
+function loadInventory() {
+  const stored = localStorage.getItem(STORAGE_KEYS.inventory);
+  if (stored) {
+    try {
+      const parsed = JSON.parse(stored);
+      if (Array.isArray(parsed) && parsed.length) {
+        return CRATE_OPTIONS.map((option) => {
+          const match = parsed.find((item) => item.id === option.id);
+          return {
+            id: option.id,
+            label: option.label,
+            stock: match?.stock ?? 0,
+            price: match?.price ?? 0
+          };
+        });
+      }
+    } catch (error) {
+      console.error('Error al leer el inventario almacenado', error);
+    }
+  }
+
+  return CRATE_OPTIONS.map((option) => ({
+    id: option.id,
+    label: option.label,
+    stock: 0,
+    price: 0
+  }));
+}
+
+function renderInventoryRows(inventory, container) {
+  container.innerHTML = inventory
+    .map(
+      (item) => `
+        <div class="table__row" role="row">
+          <span>${item.label}</span>
+          <input type="number" min="0" step="1" data-type="stock" data-id="${item.id}" value="${item.stock}">
+          <input type="number" min="0" step="0.01" data-type="price" data-id="${item.id}" value="${item.price}">
+        </div>
+      `
+    )
+    .join('');
+}
+
+function renderOrdersHistory(container) {
+  const stored = localStorage.getItem(STORAGE_KEYS.orders);
+  let orders = [];
+  if (stored) {
+    try {
+      const parsed = JSON.parse(stored);
+      if (Array.isArray(parsed)) {
+        orders = parsed;
+      }
+    } catch (error) {
+      console.error('Error al leer pedidos guardados', error);
+    }
+  }
+
+  if (!orders.length) {
+    container.innerHTML = '<li>No hay pedidos registrados aún.</li>';
+    return;
+  }
+
+  const formatter = new Intl.DateTimeFormat('es-AR', {
+    dateStyle: 'medium',
+    timeStyle: 'short'
+  });
+
+  container.innerHTML = orders
+    .slice()
+    .reverse()
+    .map((order) => {
+      const timestamp = order.timestamp ? formatter.format(new Date(order.timestamp)) : 'Fecha no disponible';
+      const quantityNumber = Number.parseInt(order.quantity ?? '', 10);
+      const hasQuantity = Number.isFinite(quantityNumber) && quantityNumber > 0;
+
+      return `
+        <li>
+          <strong>${order.storeName}</strong> (${timestamp})<br>
+          ${order.storeAddress}<br>
+          Pedido: ${hasQuantity ? `${quantityNumber} × ${order.crateSize}` : order.crateSize}
+        </li>
+      `;
+    })
+    .join('');
+}
+
+function persistAdminLogin(name) {
+  const stored = localStorage.getItem(STORAGE_KEYS.adminHistory);
+  let history = [];
+
+  if (stored) {
+    try {
+      const parsed = JSON.parse(stored);
+      if (Array.isArray(parsed)) {
+        history = parsed;
+      }
+    } catch (error) {
+      console.error('Error al leer historial de administradores', error);
+    }
+  }
+
+  history.push({ name, timestamp: Date.now() });
+  const trimmedHistory = history.slice(-20);
+  localStorage.setItem(STORAGE_KEYS.adminHistory, JSON.stringify(trimmedHistory));
+}
+
+function renderAdminHistory(container) {
+  const stored = localStorage.getItem(STORAGE_KEYS.adminHistory);
+  let history = [];
+
+  if (stored) {
+    try {
+      const parsed = JSON.parse(stored);
+      if (Array.isArray(parsed)) {
+        history = parsed;
+      }
+    } catch (error) {
+      console.error('Error al leer historial de administradores', error);
+    }
+  }
+
+  if (!history.length) {
+    container.innerHTML = '<li>Aún no hay ingresos registrados.</li>';
+    return;
+  }
+
+  const formatter = new Intl.DateTimeFormat('es-AR', {
+    dateStyle: 'medium',
+    timeStyle: 'short'
+  });
+
+  container.innerHTML = history
+    .slice()
+    .reverse()
+    .map((entry) => `
+      <li>
+        <strong>${entry.name}</strong><br>
+        ${formatter.format(new Date(entry.timestamp))}
+      </li>
+    `)
+    .join('');
+}

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -111,7 +111,7 @@ document.addEventListener('DOMContentLoaded', () => {
         id: crate.id,
         label: crate.label,
         stock: Number.isFinite(stock) && stock >= 0 ? stock : 0,
-        price: Number.isFinite(price) && price >= 0 ? Number(price.toFixed(2)) : 0
+        price: Number.isFinite(price) && price >= 0 ? price : 0
       };
     });
 
@@ -237,7 +237,7 @@ function renderInventoryRows(inventory, container) {
         <div class="table__row" role="row">
           <span>${item.label}</span>
           <input type="number" min="0" step="1" data-type="stock" data-id="${item.id}" value="${item.stock}">
-          <input type="number" min="0" step="0.01" data-type="price" data-id="${item.id}" value="${item.price}">
+          <input type="number" min="0" step="any" data-type="price" data-id="${item.id}" value="${item.price}">
         </div>
       `
     )

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -440,8 +440,13 @@ function getWeekBoundaries(date) {
   start.setDate(start.getDate() - diffToMonday);
 
   const end = new Date(start);
-  end.setDate(end.getDate() + 7);
-  end.setHours(0, 0, 0, 0);
+  end.setDate(end.getDate() + 4);
+  end.setHours(23, 59, 59, 999);
+
+  const yearEnd = new Date(start.getFullYear(), 11, 31, 23, 59, 59, 999);
+  if (end > yearEnd) {
+    end.setTime(yearEnd.getTime());
+  }
 
   return { start, end };
 }

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -1,0 +1,6 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const yearSpan = document.getElementById('year');
+  if (yearSpan) {
+    yearSpan.textContent = new Date().getFullYear();
+  }
+});

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -3,4 +3,49 @@ document.addEventListener('DOMContentLoaded', () => {
   if (yearSpan) {
     yearSpan.textContent = new Date().getFullYear();
   }
+
+  activatePage();
+  setupLinkTransitions();
 });
+
+function activatePage() {
+  if (document.body && document.body.classList.contains('page--transition')) {
+    requestAnimationFrame(() => {
+      document.body.classList.add('page--ready');
+      document.body.classList.remove('page--exit');
+    });
+  }
+}
+
+function setupLinkTransitions() {
+  const links = document.querySelectorAll('a[data-transition]');
+  links.forEach((link) => {
+    link.addEventListener('click', (event) => {
+      const href = link.getAttribute('href');
+      if (!href || href.startsWith('#') || link.target === '_blank') {
+        return;
+      }
+
+      event.preventDefault();
+      triggerPageExit(() => {
+        window.location.href = href;
+      });
+    });
+  });
+}
+
+function triggerPageExit(callback) {
+  if (!document.body) {
+    callback();
+    return;
+  }
+
+  document.body.classList.add('page--exit');
+
+  if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+    callback();
+    return;
+  }
+
+  setTimeout(callback, 350);
+}

--- a/assets/js/pedido.js
+++ b/assets/js/pedido.js
@@ -54,9 +54,12 @@ document.addEventListener('DOMContentLoaded', () => {
       reviewSection.classList.add('card--hidden');
       confirmationSection.classList.add('card--hidden');
       orderSection.classList.remove('card--hidden');
+
       if (pendingOrderContext) {
+        restoreOrderFormValues(orderForm, pendingOrderContext.order);
         pendingOrderContext = null;
       }
+
       const firstInvalid = orderForm.querySelector(':invalid');
       if (firstInvalid) {
         firstInvalid.focus();
@@ -305,6 +308,9 @@ function renderCrateOptions(
     if (price > 0) {
       metaParts.push(`Precio: ${formatCurrency(price)}`);
     }
+    if (!available) {
+      metaParts.push('Producto sin stock por el momento');
+    }
     const metaText = metaParts.join(' · ');
 
     return `
@@ -432,6 +438,33 @@ function renderOrderDetails(container, order, crateData) {
 
   const details = buildOrderDetails(order, crateData);
   container.innerHTML = details.map((detail) => `<p>${detail}</p>`).join('');
+}
+
+function restoreOrderFormValues(form, order) {
+  if (!form || !order) {
+    return;
+  }
+
+  if (form.storeName) {
+    form.storeName.value = order.storeName ?? '';
+  }
+
+  if (form.storeAddress) {
+    form.storeAddress.value = order.storeAddress ?? '';
+  }
+
+  if (form.crateQuantity) {
+    form.crateQuantity.value = Number.isFinite(order.quantity)
+      ? String(order.quantity)
+      : '';
+  }
+
+  if (order.crateId) {
+    const crateInput = form.querySelector(`input[name="crateSize"][value="${order.crateId}"]`);
+    if (crateInput && !crateInput.disabled) {
+      crateInput.checked = true;
+    }
+  }
 }
 
 function buildOrderDetails(order, crateData) {

--- a/assets/js/pedido.js
+++ b/assets/js/pedido.js
@@ -1,0 +1,106 @@
+const ORDER_STORAGE_KEY = 'frigorifico_orders';
+const INVENTORY_STORAGE_KEY = 'frigorifico_inventory';
+
+document.addEventListener('DOMContentLoaded', () => {
+  const yearSpan = document.getElementById('year');
+  if (yearSpan) {
+    yearSpan.textContent = new Date().getFullYear();
+  }
+
+  const orderSection = document.getElementById('orderSection');
+  const orderForm = document.getElementById('orderForm');
+  const confirmationSection = document.getElementById('confirmation');
+  const confirmationDetails = document.getElementById('confirmationDetails');
+  const newOrderButton = document.getElementById('newOrder');
+
+  orderForm.addEventListener('submit', (event) => {
+    event.preventDefault();
+    const formData = new FormData(orderForm);
+
+    const storeName = (formData.get('storeName') || '').toString().trim();
+    const storeAddress = (formData.get('storeAddress') || '').toString().trim();
+    const crateSize = formData.get('crateSize');
+    const quantityRaw = formData.get('crateQuantity');
+    const quantity = Number.parseInt(
+      typeof quantityRaw === 'string' ? quantityRaw : `${quantityRaw ?? ''}`,
+      10
+    );
+
+    if (!storeName || !storeAddress || !crateSize || !Number.isFinite(quantity) || quantity <= 0) {
+      return;
+    }
+
+    const order = {
+      storeName,
+      storeAddress,
+      crateSize,
+      quantity,
+      timestamp: Date.now()
+    };
+
+    persistOrder(order);
+
+    const inventory = loadInventory();
+    const crateData = inventory.find((item) => item.label.includes(crateSize));
+    const details = [
+      `<strong>Comercio:</strong> ${storeName}`,
+      `<strong>Dirección:</strong> ${storeAddress}`,
+      `<strong>Cantidad:</strong> ${quantity} cajones`,
+      `<strong>Cajón solicitado:</strong> ${crateSize}`
+    ];
+
+    if (crateData) {
+      details.push(`<strong>Precio vigente:</strong> ARS ${Number(crateData.price || 0).toLocaleString('es-AR', { minimumFractionDigits: 2 })}`);
+      details.push(`<strong>Stock disponible:</strong> ${crateData.stock} cajones`);
+    }
+
+    confirmationDetails.innerHTML = details
+      .map((detail) => `<p>${detail}</p>`)
+      .join('');
+
+    orderSection.classList.add('card--hidden');
+    confirmationSection.classList.remove('card--hidden');
+    orderForm.reset();
+  });
+
+  newOrderButton.addEventListener('click', () => {
+    confirmationSection.classList.add('card--hidden');
+    orderSection.classList.remove('card--hidden');
+    confirmationDetails.innerHTML = '';
+  });
+});
+
+function persistOrder(order) {
+  const stored = localStorage.getItem(ORDER_STORAGE_KEY);
+  let orders = [];
+
+  if (stored) {
+    try {
+      const parsed = JSON.parse(stored);
+      if (Array.isArray(parsed)) {
+        orders = parsed;
+      }
+    } catch (error) {
+      console.error('Error al leer pedidos guardados', error);
+    }
+  }
+
+  orders.push(order);
+  localStorage.setItem(ORDER_STORAGE_KEY, JSON.stringify(orders));
+}
+
+function loadInventory() {
+  const stored = localStorage.getItem(INVENTORY_STORAGE_KEY);
+  if (stored) {
+    try {
+      const parsed = JSON.parse(stored);
+      if (Array.isArray(parsed)) {
+        return parsed;
+      }
+    } catch (error) {
+      console.error('Error al leer el inventario', error);
+    }
+  }
+
+  return [];
+}

--- a/assets/js/pedido.js
+++ b/assets/js/pedido.js
@@ -94,7 +94,14 @@ document.addEventListener('DOMContentLoaded', () => {
       orderForm.reset();
       hideMessage(orderMessage);
       hideAlert(globalAlert);
-      renderCrateOptions(crateOptionsContainer, inventory, submitButton, orderMessage, globalAlert);
+      renderCrateOptions(
+        crateOptionsContainer,
+        inventory,
+        submitButton,
+        orderMessage,
+        globalAlert,
+        { preserveAlerts: true, preserveMessage: true }
+      );
     });
   }
 
@@ -254,10 +261,20 @@ function normalizeInventory(inventory) {
   });
 }
 
-function renderCrateOptions(container, inventory, submitButton, messageContainer, alertContainer) {
+function renderCrateOptions(
+  container,
+  inventory,
+  submitButton,
+  messageContainer,
+  alertContainer,
+  options
+) {
   if (!container) {
     return;
   }
+
+  const preserveAlerts = !!(options && typeof options === 'object' && options.preserveAlerts);
+  const preserveMessage = !!(options && typeof options === 'object' && options.preserveMessage);
 
   let availableCount = 0;
 
@@ -305,8 +322,12 @@ function renderCrateOptions(container, inventory, submitButton, messageContainer
         + 'Por favor, vuelva a intentar más tarde.'
     );
   } else {
-    hideMessage(messageContainer);
-    hideAlert(alertContainer);
+    if (!preserveMessage) {
+      hideMessage(messageContainer);
+    }
+    if (!preserveAlerts) {
+      hideAlert(alertContainer);
+    }
   }
 }
 

--- a/assets/js/pedido.js
+++ b/assets/js/pedido.js
@@ -159,7 +159,14 @@ document.addEventListener('DOMContentLoaded', () => {
 
     if (!crateData || availableStock <= 0) {
       displayMessage(orderMessage, 'No hay stock disponible para el cajón seleccionado.');
-      renderCrateOptions(crateOptionsContainer, inventory, submitButton, orderMessage, globalAlert);
+      renderCrateOptions(
+        crateOptionsContainer,
+        inventory,
+        submitButton,
+        orderMessage,
+        globalAlert,
+        { preserveAlerts: true, preserveMessage: true }
+      );
       return;
     }
 
@@ -172,7 +179,14 @@ document.addEventListener('DOMContentLoaded', () => {
         : `Se está excediendo del stock disponible. El stock restante es ${availableStock} ${availableStock === 1 ? 'cajón' : 'cajones'}.`;
       displayMessage(orderMessage, stockMessage);
       showAlert(globalAlert, alertMessage);
-      renderCrateOptions(crateOptionsContainer, inventory, submitButton, orderMessage, globalAlert);
+      renderCrateOptions(
+        crateOptionsContainer,
+        inventory,
+        submitButton,
+        orderMessage,
+        globalAlert,
+        { preserveAlerts: true, preserveMessage: true }
+      );
       return;
     }
 

--- a/assets/js/pedido.js
+++ b/assets/js/pedido.js
@@ -715,8 +715,6 @@ function renderConfirmation(container, order, crateData) {
     summaryFragments.push(`El total estimado es ${formatCurrency(totalPrice)}.`);
   }
 
-  summaryFragments.push('Nos comunicaremos para coordinar la disponibilidad.');
-
   container.innerHTML = `
     <p class="confirmation__message">${summaryFragments.join(' ')}</p>
     <ul class="confirmation__list">

--- a/assets/js/pedido.js
+++ b/assets/js/pedido.js
@@ -276,34 +276,18 @@ function hideMessage(container) {
 }
 
 function isOrderLocked() {
-  return localStorage.getItem(ORDER_LOCK_KEY) === 'true';
+  if (localStorage.getItem(ORDER_LOCK_KEY)) {
+    localStorage.removeItem(ORDER_LOCK_KEY);
+  }
+  return false;
 }
 
 function lockOrdering() {
-  localStorage.setItem(ORDER_LOCK_KEY, 'true');
+  localStorage.removeItem(ORDER_LOCK_KEY);
 }
 
 function resetOrderLockIfNeeded() {
-  if (localStorage.getItem(ORDER_LOCK_KEY) !== 'true') {
-    return;
-  }
-
-  const lastOrder = getLastOrder();
-  const orderTimestamp = Number(lastOrder?.timestamp);
-
-  if (!Number.isFinite(orderTimestamp)) {
-    localStorage.removeItem(ORDER_LOCK_KEY);
-    return;
-  }
-
-  const nextMondayTimestamp = calculateNextMondayTimestamp(orderTimestamp);
-
-  if (!Number.isFinite(nextMondayTimestamp)) {
-    localStorage.removeItem(ORDER_LOCK_KEY);
-    return;
-  }
-
-  if (Date.now() >= nextMondayTimestamp) {
+  if (localStorage.getItem(ORDER_LOCK_KEY)) {
     localStorage.removeItem(ORDER_LOCK_KEY);
   }
 }

--- a/assets/js/pedido.js
+++ b/assets/js/pedido.js
@@ -1,5 +1,15 @@
 const ORDER_STORAGE_KEY = 'frigorifico_orders';
 const INVENTORY_STORAGE_KEY = 'frigorifico_inventory';
+const ORDER_LOCK_KEY = 'frigorifico_order_lock';
+
+const CRATE_OPTIONS = [
+  { id: 'X', label: 'Cajón X' },
+  { id: '6', label: 'Cajón de 6 cabezas' },
+  { id: '7', label: 'Cajón de 7 cabezas' },
+  { id: '8', label: 'Cajón de 8 cabezas' },
+  { id: '9', label: 'Cajón de 9 cabezas' },
+  { id: '10', label: 'Cajón de 10 cabezas' }
+];
 
 document.addEventListener('DOMContentLoaded', () => {
   const yearSpan = document.getElementById('year');
@@ -11,62 +21,121 @@ document.addEventListener('DOMContentLoaded', () => {
   const orderForm = document.getElementById('orderForm');
   const confirmationSection = document.getElementById('confirmation');
   const confirmationDetails = document.getElementById('confirmationDetails');
-  const newOrderButton = document.getElementById('newOrder');
+  const crateOptionsContainer = document.getElementById('crateOptions');
+  const orderMessage = document.getElementById('orderMessage');
+  const submitButton = orderForm.querySelector('button[type="submit"]');
+
+  let inventory = normalizeInventory(loadInventory());
+
+  if (isOrderLocked()) {
+    showLockedConfirmation(orderSection, confirmationSection, confirmationDetails, inventory);
+    return;
+  }
+
+  renderCrateOptions(crateOptionsContainer, inventory, submitButton, orderMessage);
+
+  orderForm.addEventListener('input', () => {
+    hideMessage(orderMessage);
+  });
 
   orderForm.addEventListener('submit', (event) => {
     event.preventDefault();
+
+    if (isOrderLocked()) {
+      showLockedConfirmation(orderSection, confirmationSection, confirmationDetails, inventory);
+      return;
+    }
+
     const formData = new FormData(orderForm);
 
     const storeName = (formData.get('storeName') || '').toString().trim();
     const storeAddress = (formData.get('storeAddress') || '').toString().trim();
-    const crateSize = formData.get('crateSize');
+    const crateId = (formData.get('crateSize') || '').toString();
     const quantityRaw = formData.get('crateQuantity');
     const quantity = Number.parseInt(
       typeof quantityRaw === 'string' ? quantityRaw : `${quantityRaw ?? ''}`,
       10
     );
 
-    if (!storeName || !storeAddress || !crateSize || !Number.isFinite(quantity) || quantity <= 0) {
+    hideMessage(orderMessage);
+
+    if (!storeName) {
+      displayMessage(orderMessage, 'Ingrese el nombre de su local para continuar.');
+      orderForm.storeName.focus();
       return;
     }
+
+    if (!storeAddress) {
+      displayMessage(orderMessage, 'Ingrese la dirección completa del local.');
+      orderForm.storeAddress.focus();
+      return;
+    }
+
+    if (!crateId) {
+      displayMessage(orderMessage, 'Seleccione un cajón disponible.');
+      return;
+    }
+
+    if (!Number.isFinite(quantity) || quantity <= 0) {
+      displayMessage(orderMessage, 'La cantidad debe ser un número válido mayor que cero.');
+      orderForm.crateQuantity.focus();
+      return;
+    }
+
+    inventory = normalizeInventory(loadInventory());
+
+    const crateData = inventory.find((item) => item.id === crateId);
+    const availableStock = Number.isFinite(crateData?.stock)
+      ? Number.parseInt(crateData.stock, 10)
+      : 0;
+
+    if (!crateData || availableStock <= 0) {
+      displayMessage(orderMessage, 'No hay stock disponible para el cajón seleccionado.');
+      renderCrateOptions(crateOptionsContainer, inventory, submitButton, orderMessage);
+      return;
+    }
+
+    if (quantity > availableStock) {
+      displayMessage(
+        orderMessage,
+        `Solo quedan ${availableStock} cajones disponibles de ese tipo.`
+      );
+      renderCrateOptions(crateOptionsContainer, inventory, submitButton, orderMessage);
+      return;
+    }
+
+    const remainingStock = availableStock - quantity;
+    const updatedInventory = inventory.map((item) =>
+      item.id === crateId ? { ...item, stock: remainingStock } : item
+    );
+
+    persistInventory(updatedInventory);
+    inventory = updatedInventory;
+
+    const crateLabel = crateData.label;
 
     const order = {
       storeName,
       storeAddress,
-      crateSize,
+      crateSize: crateLabel,
+      crateId,
       quantity,
       timestamp: Date.now()
     };
 
     persistOrder(order);
+    lockOrdering();
 
-    const inventory = loadInventory();
-    const crateData = inventory.find((item) => item.label.includes(crateSize));
-    const details = [
-      `<strong>Comercio:</strong> ${storeName}`,
-      `<strong>Dirección:</strong> ${storeAddress}`,
-      `<strong>Cantidad:</strong> ${quantity} cajones`,
-      `<strong>Cajón solicitado:</strong> ${crateSize}`
-    ];
-
-    if (crateData) {
-      details.push(`<strong>Precio vigente:</strong> ARS ${Number(crateData.price || 0).toLocaleString('es-AR', { minimumFractionDigits: 2 })}`);
-      details.push(`<strong>Stock disponible:</strong> ${crateData.stock} cajones`);
-    }
-
-    confirmationDetails.innerHTML = details
-      .map((detail) => `<p>${detail}</p>`)
-      .join('');
+    renderConfirmation(
+      confirmationDetails,
+      order,
+      updatedInventory.find((item) => item.id === crateId) ?? null
+    );
 
     orderSection.classList.add('card--hidden');
     confirmationSection.classList.remove('card--hidden');
     orderForm.reset();
-  });
-
-  newOrderButton.addEventListener('click', () => {
-    confirmationSection.classList.add('card--hidden');
-    orderSection.classList.remove('card--hidden');
-    confirmationDetails.innerHTML = '';
+    renderCrateOptions(crateOptionsContainer, inventory, submitButton, orderMessage);
   });
 });
 
@@ -103,4 +172,160 @@ function loadInventory() {
   }
 
   return [];
+}
+
+function normalizeInventory(inventory) {
+  const source = Array.isArray(inventory) ? inventory : [];
+  return CRATE_OPTIONS.map((option) => {
+    const match = source.find((item) => item.id === option.id) ?? {};
+    const stockValue = Number.parseInt(match.stock ?? 0, 10);
+    const priceValue = Number.parseFloat(match.price ?? 0);
+    return {
+      id: option.id,
+      label: option.label,
+      stock: Number.isFinite(stockValue) && stockValue > 0 ? stockValue : 0,
+      price: Number.isFinite(priceValue) && priceValue > 0 ? Number(priceValue.toFixed(2)) : 0
+    };
+  });
+}
+
+function renderCrateOptions(container, inventory, submitButton, messageContainer) {
+  if (!container) {
+    return;
+  }
+
+  let availableCount = 0;
+
+  container.innerHTML = CRATE_OPTIONS.map((option) => {
+    const data = inventory.find((item) => item.id === option.id) ?? option;
+    const stock = Number.isFinite(data.stock) ? Number.parseInt(data.stock, 10) : 0;
+    const price = Number.isFinite(data.price) ? Number(data.price) : 0;
+    const available = stock > 0;
+    if (available) {
+      availableCount += 1;
+    }
+
+    const priceText = price > 0 ? ` · Precio: ${formatCurrency(price)}` : '';
+    const stockText = `Stock: ${stock} ${stock === 1 ? 'cajón' : 'cajones'}`;
+
+    return `
+      <label class="radio${available ? '' : ' radio--disabled'}">
+        <input type="radio" name="crateSize" value="${option.id}" data-label="${option.label}" ${available ? '' : 'disabled'}>
+        <span class="radio__title">${option.label}</span>
+        <span class="radio__meta">${stockText}${priceText}</span>
+      </label>
+    `;
+  }).join('');
+
+  const firstEnabled = container.querySelector('input[name="crateSize"]:not([disabled])');
+  if (firstEnabled) {
+    firstEnabled.required = true;
+  }
+
+  if (submitButton) {
+    submitButton.disabled = availableCount === 0;
+  }
+
+  if (availableCount === 0) {
+    displayMessage(
+      messageContainer,
+      'En este momento no hay stock disponible para realizar pedidos.'
+    );
+  } else {
+    hideMessage(messageContainer);
+  }
+}
+
+function persistInventory(inventory) {
+  localStorage.setItem(INVENTORY_STORAGE_KEY, JSON.stringify(inventory));
+}
+
+function formatCurrency(value) {
+  return Number(value).toLocaleString('es-AR', {
+    style: 'currency',
+    currency: 'ARS',
+    minimumFractionDigits: 2
+  });
+}
+
+function displayMessage(container, message) {
+  if (!container) {
+    return;
+  }
+
+  container.textContent = message;
+  container.hidden = !message;
+}
+
+function hideMessage(container) {
+  if (!container) {
+    return;
+  }
+
+  container.textContent = '';
+  container.hidden = true;
+}
+
+function isOrderLocked() {
+  return localStorage.getItem(ORDER_LOCK_KEY) === 'true';
+}
+
+function lockOrdering() {
+  localStorage.setItem(ORDER_LOCK_KEY, 'true');
+}
+
+function getLastOrder() {
+  const stored = localStorage.getItem(ORDER_STORAGE_KEY);
+  if (stored) {
+    try {
+      const parsed = JSON.parse(stored);
+      if (Array.isArray(parsed) && parsed.length) {
+        return parsed[parsed.length - 1];
+      }
+    } catch (error) {
+      console.error('Error al recuperar el último pedido', error);
+    }
+  }
+  return null;
+}
+
+function renderConfirmation(container, order, crateData) {
+  if (!container || !order) {
+    return;
+  }
+
+  const details = [
+    `<strong>Comercio:</strong> ${order.storeName}`,
+    `<strong>Dirección:</strong> ${order.storeAddress}`,
+    `<strong>Cantidad:</strong> ${order.quantity} ${order.quantity === 1 ? 'cajón' : 'cajones'}`,
+    `<strong>Cajón solicitado:</strong> ${order.crateSize}`
+  ];
+
+  if (crateData) {
+    if (crateData.price) {
+      details.push(`<strong>Precio vigente:</strong> ${formatCurrency(crateData.price)}`);
+    }
+    details.push(
+      `<strong>Stock restante:</strong> ${crateData.stock} ${crateData.stock === 1 ? 'cajón' : 'cajones'}`
+    );
+  }
+
+  container.innerHTML = details.map((detail) => `<p>${detail}</p>`).join('');
+}
+
+function showLockedConfirmation(orderSection, confirmationSection, confirmationDetails, inventory) {
+  if (orderSection) {
+    orderSection.classList.add('card--hidden');
+  }
+  if (confirmationSection) {
+    confirmationSection.classList.remove('card--hidden');
+  }
+
+  const lastOrder = getLastOrder();
+  if (lastOrder) {
+    const crateData = inventory.find((item) => item.id === lastOrder.crateId) ?? null;
+    renderConfirmation(confirmationDetails, lastOrder, crateData);
+  } else if (confirmationDetails) {
+    confirmationDetails.innerHTML = '<p>No hay detalles para mostrar en este momento.</p>';
+  }
 }

--- a/index.html
+++ b/index.html
@@ -6,14 +6,14 @@
   <title>Frigorífico Kosher - Pedidos Mayoristas</title>
   <link rel="stylesheet" href="assets/css/styles.css">
 </head>
-<body>
+<body class="page page--transition">
   <header class="hero">
     <div class="hero__content">
       <h1>Frigorífico Kosher</h1>
       <p>Distribución mayorista de pollos kosher en cajones seleccionados.</p>
       <div class="hero__links">
-        <a class="button" href="admin.html">Acceso administradores</a>
-        <a class="button button--secondary" href="pedido.html">Realizar pedido</a>
+        <a class="button" href="admin.html" data-transition>Acceso administradores</a>
+        <a class="button button--secondary" href="pedido.html" data-transition>Realizar pedido</a>
       </div>
     </div>
   </header>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Frigorífico Kosher - Pedidos Mayoristas</title>
+  <link rel="stylesheet" href="assets/css/styles.css">
+</head>
+<body>
+  <header class="hero">
+    <div class="hero__content">
+      <h1>Frigorífico Kosher</h1>
+      <p>Distribución mayorista de pollos kosher en cajones seleccionados.</p>
+      <div class="hero__links">
+        <a class="button" href="admin.html">Acceso administradores</a>
+        <a class="button button--secondary" href="pedido.html">Realizar pedido</a>
+      </div>
+    </div>
+  </header>
+
+  <main class="container">
+    <section class="card">
+      <h2>Nuestros productos</h2>
+      <p>
+        Trabajamos exclusivamente con cajones de pollos kosher cuidadosamente seleccionados.
+        No realizamos pedidos particulares, únicamente ventas por cajones.
+      </p>
+      <ul class="list">
+        <li>Cajón X</li>
+        <li>Cajones mixtos de 6 cabezas</li>
+        <li>Cajones mixtos de 7 cabezas</li>
+        <li>Cajones mixtos de 8 cabezas</li>
+        <li>Cajones mixtos de 9 cabezas</li>
+        <li>Cajones mixtos de 10 cabezas</li>
+      </ul>
+    </section>
+
+    <section class="card card--highlight">
+      <h2>¿Cómo trabajamos?</h2>
+      <ol class="list list--ordered">
+        <li>El administrador actualiza precios y stock disponibles.</li>
+        <li>Los clientes mayoristas envían su pedido indicando su comercio y dirección.</li>
+        <li>Confirmamos la disponibilidad y coordinamos la entrega.</li>
+      </ol>
+      <p>
+        Haga clic en el enlace correspondiente para continuar según su perfil.
+      </p>
+    </section>
+  </main>
+
+  <footer class="footer">
+    <p>&copy; <span id="year"></span> Frigorífico Kosher. Todos los derechos reservados.</p>
+  </footer>
+
+  <script src="assets/js/index.js"></script>
+</body>
+</html>

--- a/pedido.html
+++ b/pedido.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Enviar pedido - Frigorífico Kosher</title>
+  <link rel="stylesheet" href="assets/css/styles.css">
+</head>
+<body>
+  <header class="subheader">
+    <a class="subheader__back" href="index.html">&larr; Inicio</a>
+    <h1>Solicitud de pedido mayorista</h1>
+  </header>
+
+  <main class="container">
+    <section class="card" id="orderSection">
+      <h2>Complete los datos de su comercio</h2>
+      <form id="orderForm" class="form">
+        <label for="storeName">Nombre del local</label>
+        <input id="storeName" name="storeName" type="text" required placeholder="Ej: Carnicería Kosher Central">
+
+        <label for="storeAddress">Dirección completa</label>
+        <input id="storeAddress" name="storeAddress" type="text" required placeholder="Ej: Av. Ejemplo 1234, CABA">
+
+        <label for="crateQuantity">Cantidad de cajones</label>
+        <input
+          id="crateQuantity"
+          name="crateQuantity"
+          type="number"
+          min="1"
+          step="1"
+          required
+          placeholder="Ej: 3"
+        >
+
+        <fieldset class="form__fieldset">
+          <legend>¿Qué cajón necesita?</legend>
+          <label class="radio">
+            <input type="radio" name="crateSize" value="Cajón X" required>
+            Cajón X
+          </label>
+          <label class="radio">
+            <input type="radio" name="crateSize" value="6 cabezas" required>
+            Cajón de 6 cabezas
+          </label>
+          <label class="radio">
+            <input type="radio" name="crateSize" value="7 cabezas">
+            Cajón de 7 cabezas
+          </label>
+          <label class="radio">
+            <input type="radio" name="crateSize" value="8 cabezas">
+            Cajón de 8 cabezas
+          </label>
+          <label class="radio">
+            <input type="radio" name="crateSize" value="9 cabezas">
+            Cajón de 9 cabezas
+          </label>
+          <label class="radio">
+            <input type="radio" name="crateSize" value="10 cabezas">
+            Cajón de 10 cabezas
+          </label>
+        </fieldset>
+
+        <button class="button" type="submit">Enviar pedido</button>
+      </form>
+    </section>
+
+    <section class="card card--hidden" id="confirmation">
+      <h2>¡Gracias por su pedido!</h2>
+      <p>Hemos registrado su solicitud. Un representante se comunicará para confirmar la disponibilidad.</p>
+      <div class="confirmation__details" id="confirmationDetails"></div>
+      <button class="button button--secondary" id="newOrder">Cargar otro pedido</button>
+    </section>
+  </main>
+
+  <footer class="footer">
+    <p>&copy; <span id="year"></span> Frigorífico Kosher. Ventas mayoristas.</p>
+  </footer>
+
+  <script src="assets/js/pedido.js"></script>
+</body>
+</html>

--- a/pedido.html
+++ b/pedido.html
@@ -33,33 +33,12 @@
           placeholder="Ej: 3"
         >
 
-        <fieldset class="form__fieldset">
+        <fieldset class="form__fieldset" id="crateOptionsFieldset">
           <legend>¿Qué cajón necesita?</legend>
-          <label class="radio">
-            <input type="radio" name="crateSize" value="Cajón X" required>
-            Cajón X
-          </label>
-          <label class="radio">
-            <input type="radio" name="crateSize" value="6 cabezas" required>
-            Cajón de 6 cabezas
-          </label>
-          <label class="radio">
-            <input type="radio" name="crateSize" value="7 cabezas">
-            Cajón de 7 cabezas
-          </label>
-          <label class="radio">
-            <input type="radio" name="crateSize" value="8 cabezas">
-            Cajón de 8 cabezas
-          </label>
-          <label class="radio">
-            <input type="radio" name="crateSize" value="9 cabezas">
-            Cajón de 9 cabezas
-          </label>
-          <label class="radio">
-            <input type="radio" name="crateSize" value="10 cabezas">
-            Cajón de 10 cabezas
-          </label>
+          <div id="crateOptions"></div>
         </fieldset>
+
+        <p class="form__message form__message--error" id="orderMessage" hidden aria-live="polite"></p>
 
         <button class="button" type="submit">Enviar pedido</button>
       </form>
@@ -69,7 +48,7 @@
       <h2>¡Gracias por su pedido!</h2>
       <p>Hemos registrado su solicitud. Un representante se comunicará para confirmar la disponibilidad.</p>
       <div class="confirmation__details" id="confirmationDetails"></div>
-      <button class="button button--secondary" id="newOrder">Cargar otro pedido</button>
+      <p class="form__message">No es posible registrar un nuevo pedido desde este dispositivo.</p>
     </section>
   </main>
 

--- a/pedido.html
+++ b/pedido.html
@@ -48,7 +48,6 @@
       <h2>¡Gracias por su pedido!</h2>
       <p>Hemos registrado su solicitud. Un representante se comunicará para confirmar la disponibilidad.</p>
       <div class="confirmation__details" id="confirmationDetails"></div>
-      <p class="form__message">No es posible registrar un nuevo pedido desde este dispositivo.</p>
     </section>
   </main>
 

--- a/pedido.html
+++ b/pedido.html
@@ -13,6 +13,8 @@
   </header>
 
   <main class="container">
+    <div class="alert alert--warning" id="globalAlert" hidden role="alert"></div>
+
     <section class="card" id="orderSection">
       <h2>Complete los datos de su comercio</h2>
       <form id="orderForm" class="form">
@@ -42,6 +44,16 @@
 
         <button class="button" type="submit">Enviar pedido</button>
       </form>
+    </section>
+
+    <section class="card card--hidden" id="reviewSection">
+      <h2>Revisá tu pedido</h2>
+      <p class="review__intro">Por seguridad, verificá que los datos sean correctos antes de confirmar.</p>
+      <div class="confirmation__details" id="reviewDetails"></div>
+      <div class="review__actions">
+        <button class="button button--secondary" type="button" id="reviewBack">Volver para editar</button>
+        <button class="button" type="button" id="reviewConfirm">Confirmar pedido</button>
+      </div>
     </section>
 
     <section class="card card--hidden" id="confirmation">

--- a/pedido.html
+++ b/pedido.html
@@ -6,9 +6,9 @@
   <title>Enviar pedido - Frigorífico Kosher</title>
   <link rel="stylesheet" href="assets/css/styles.css">
 </head>
-<body>
+<body class="page page--transition">
   <header class="subheader">
-    <a class="subheader__back" href="index.html">&larr; Inicio</a>
+    <a class="subheader__back" href="index.html" data-transition>&larr; Inicio</a>
     <h1>Solicitud de pedido mayorista</h1>
   </header>
 
@@ -56,8 +56,16 @@
       </div>
     </section>
 
+    <section class="card card--hidden" id="processingSection" aria-live="polite">
+      <h2>Registrando su pedido</h2>
+      <p>Estamos guardando los datos. Aguarde mientras completamos el proceso.</p>
+      <div class="progress">
+        <div class="progress__bar" id="processingBar"></div>
+      </div>
+    </section>
+
     <section class="card card--hidden" id="confirmation">
-      <h2>¡Gracias por su pedido!</h2>
+      <h2>¡Gracias por su compra!</h2>
       <div class="confirmation__details" id="confirmationDetails"></div>
     </section>
   </main>

--- a/pedido.html
+++ b/pedido.html
@@ -46,7 +46,6 @@
 
     <section class="card card--hidden" id="confirmation">
       <h2>¡Gracias por su pedido!</h2>
-      <p>Hemos registrado su solicitud. Un representante se comunicará para confirmar la disponibilidad.</p>
       <div class="confirmation__details" id="confirmationDetails"></div>
     </section>
   </main>

--- a/pedido.html
+++ b/pedido.html
@@ -60,11 +60,12 @@
       <h2>Registrando su pedido</h2>
       <p>Estamos guardando los datos. Aguarde mientras completamos el proceso.</p>
       <div class="progress">
+        <span class="progress__label" id="processingPercent">0%</span>
         <div class="progress__bar" id="processingBar"></div>
       </div>
     </section>
 
-    <section class="card card--hidden" id="confirmation">
+    <section class="card card--hidden card--thanks" id="confirmation">
       <h2>¡Gracias por su compra!</h2>
       <div class="confirmation__details" id="confirmationDetails"></div>
     </section>

--- a/pedido.html
+++ b/pedido.html
@@ -8,7 +8,10 @@
 </head>
 <body class="page page--transition">
   <header class="subheader">
-    <a class="subheader__back" href="index.html" data-transition>&larr; Inicio</a>
+    <a class="subheader__back" href="index.html" data-transition>
+      <span class="subheader__icon" aria-hidden="true">🏠</span>
+      <span class="subheader__label">Salir</span>
+    </a>
     <h1>Solicitud de pedido mayorista</h1>
   </header>
 


### PR DESCRIPTION
## Summary
- permitir que el formulario de pedidos capture la cantidad solicitada y mostrarla en la confirmación
- agregar el cajón X a la oferta, incluyendo su gestión en el panel administrativo y en el historial de pedidos
- actualizar la página principal para reflejar la nueva opción disponible

## Testing
- no automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cd52be67308332968be52a37f28ab2